### PR TITLE
Possible fix for github issue #109: calendar overview shows previous date not the selected date

### DIFF
--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -113,7 +113,7 @@ public class Maya.View.AgendaView : Gtk.Grid {
                 return false;
 
             unowned iCal.Component comp = event_row.calevent.get_icalcomponent ();
-            var stripped_time = Util.strip_time (selected_date.to_timezone (new TimeZone.utc ()));
+			var stripped_time = new DateTime.utc(selected_date.get_year(), selected_date.get_month(), selected_date.get_day_of_month(), 0, 0, 0);
             var range = new Util.DateRange (stripped_time, stripped_time.add_days (1));
             foreach (var dt_range in Util.event_date_ranges (comp, range)) {
                 if (dt_range.contains (stripped_time))

--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -113,7 +113,7 @@ public class Maya.View.AgendaView : Gtk.Grid {
                 return false;
 
             unowned iCal.Component comp = event_row.calevent.get_icalcomponent ();
-            var stripped_time = new DateTime.utc(selected_date.get_year(), selected_date.get_month(), selected_date.get_day_of_month(), 0, 0, 0);
+            var stripped_time = new DateTime.utc (selected_date.get_year (), selected_date.get_month (), selected_date.get_day_of_month (), 0, 0, 0);
             var range = new Util.DateRange (stripped_time, stripped_time.add_days (1));
             foreach (var dt_range in Util.event_date_ranges (comp, range)) {
                 if (dt_range.contains (stripped_time))

--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -113,7 +113,7 @@ public class Maya.View.AgendaView : Gtk.Grid {
                 return false;
 
             unowned iCal.Component comp = event_row.calevent.get_icalcomponent ();
-			var stripped_time = new DateTime.utc(selected_date.get_year(), selected_date.get_month(), selected_date.get_day_of_month(), 0, 0, 0);
+            var stripped_time = new DateTime.utc(selected_date.get_year(), selected_date.get_month(), selected_date.get_day_of_month(), 0, 0, 0);
             var range = new Util.DateRange (stripped_time, stripped_time.add_days (1));
             foreach (var dt_range in Util.event_date_ranges (comp, range)) {
                 if (dt_range.contains (stripped_time))


### PR DESCRIPTION
When selecting a day in the grid, the sorting method of the AgendaView gets the selected date in local timezone, in this form:

YYY-MM-DDT00:00:00[+|-]hhmm

Then the AgendaView proceeds to get the events of this date, using a sorting function that does:

(1) Gets the selected date and converts to UTC
(2) Strips the new date from everything except year, month and day
(3) Generates a time range from what it gets in (2) to the same date plus one day
(4) Gets all events whithin the range generated in (3)


The problem lies in (2), when in timezones at the East respect UTC.

Lets check what happens with two examples with the steps 1-3 described above:

First example: the selected date is 2017-05-17T00:00:00-0600, which is at the West respect UTC timezone

(1) 2017-05-17T00:00:00-0600 to UTC : 2017-05-17T05:00:00+0000
(2) 2017-05-17T05:00:00+0000 strip: 2017-05-17T00:00:00+0000
(3) 2017-05-17T00:00:00+0000 generates range: FROM:2017-05-17T00:00:00+0000 TO:2017-05-18T00:00:00+0000

This is OK.


Second example: the selected date is 2017-05-17T00:00:00+0200, which is at the East respect UTC timezone

(1) 2017-05-17T00:00:00+0200 to UTC : 2017-05-16T02:00:00+0000
(2) 2017-05-16T02:00:00+0000 strip: 2017-05-16T00:00:00+0000
(3) 2017-05-16T00:00:00+0000 generates range: FROM:2017-05-16T00:00:00+0000 TO:2017-05-17T00:00:00+0000

This is not OK. AgendaView will show event of the day prior to the selected one.


This might be fixed with the simple change proposed in the pull request (seems to work as expected), but as I am not familiar with this codebase,  this might be just a dirty hack for an underlying problem elsewhere. Anyway, I hope this helps.

