### PR TITLE
Correctly generate date ranges for all day events (#132)

### DIFF
--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -156,9 +156,6 @@ namespace Maya.Util {
         bool allday = is_all_day (start, end);
         if (allday) {
             end = end.add_days (-1);
-            var interval = (new DateTime.now_local ()).get_utc_offset ();
-            start = start.add (-interval);
-            end = end.add (-interval);
         }
 
         start = strip_time (start);


### PR DESCRIPTION
Adding the interval can cause in certain timezones all day events to show up on the wrong day, particularly the day before.