### PR TITLE
Show multi-day all day events correctly #137

### DIFF
--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -119,9 +119,6 @@ namespace Maya.Util {
         bool allday = is_all_day (start, end);
         if (allday) {
             end = end.add_days (-1);
-            var interval = (new DateTime.now_local ()).get_utc_offset ();
-            start = start.add (-interval);
-            end = end.add (-interval);  
         }
 
         int c1 = start.compare (view_range.first);


### PR DESCRIPTION
Similarly to #136 the interval being added can cause the agenda view to show the event on the wrong days