### PR TITLE
Implement exporting of calendar #30

### DIFF
--- a/core/Model/CalendarModel.vala
+++ b/core/Model/CalendarModel.vala
@@ -253,6 +253,17 @@ public class Maya.Model.CalendarModel : Object {
         events_removed (source, events);
         source_events.remove (source);
     }
+    
+    public Gee.Collection<E.CalComponent> get_events () {
+        Gee.ArrayList<E.CalComponent> events = new Gee.ArrayList<E.CalComponent> ();
+        registry.list_sources (E.SOURCE_EXTENSION_CALENDAR).foreach ((source) => {
+            E.SourceCalendar cal = (E.SourceCalendar)source.get_extension (E.SOURCE_EXTENSION_CALENDAR);
+            if (cal.selected == true && source.enabled == true) {
+                events.add_all (source_events.get (source).values.read_only_view);
+            }
+        });
+        return events;
+    }
 
     //--- Helper Methods ---//
 

--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -709,7 +709,6 @@ namespace Maya.Util {
             builder.append (event.get_as_string ());
         }
         builder.append ("END:VCALENDAR");
-        string output = builder.str;   
 
         string file_path = GLib.Environment.get_tmp_dir () + "/calendar.ics";
         try {
@@ -718,7 +717,7 @@ namespace Maya.Util {
                 file.delete ();
             }
             var dos = new DataOutputStream (file.create (FileCreateFlags.REPLACE_DESTINATION));
-            uint8[] data = output.data;
+            uint8[] data = builder.data;
             long written = 0;
             while (written < data.length) {
                 written += dos.write (data[written:data.length]);

--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -699,8 +699,33 @@ namespace Maya.Util {
      * ical Exportation
      */
 
-    public void save_temp_selected_calendars (){
-        //TODO:Create the code !
+    public void save_temp_selected_calendars () {
+        var calmodel = Model.CalendarModel.get_default ();
+        var events = calmodel.get_events ();
+        var builder = new StringBuilder ();
+        builder.append ("BEGIN:VCALENDAR\n");
+        builder.append ("VERSION:2.0\n");
+        foreach (E.CalComponent event in events) {
+            builder.append (event.get_as_string ());
+        }
+        builder.append ("END:VCALENDAR");
+        string output = builder.str;   
+
+        string file_path = GLib.Environment.get_tmp_dir () + "/calendar.ics";
+        try {
+            var file = File.new_for_path (file_path);
+            if (file.query_exists ()) {
+                file.delete ();
+            }
+            var dos = new DataOutputStream (file.create (FileCreateFlags.REPLACE_DESTINATION));
+            uint8[] data = output.data;
+            long written = 0;
+            while (written < data.length) {
+                written += dos.write (data[written:data.length]);
+            }
+        } catch (Error e) {
+            warning ("%s\n", e.message);
+        }
     }
 
     public string get_hexa_color (Gdk.RGBA color) {

--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -713,15 +713,7 @@ namespace Maya.Util {
         string file_path = GLib.Environment.get_tmp_dir () + "/calendar.ics";
         try {
             var file = File.new_for_path (file_path);
-            if (file.query_exists ()) {
-                file.delete ();
-            }
-            var dos = new DataOutputStream (file.create (FileCreateFlags.REPLACE_DESTINATION));
-            uint8[] data = builder.data;
-            long written = 0;
-            while (written < data.length) {
-                written += dos.write (data[written:data.length]);
-            }
+            file.replace_contents (builder.data, null, false, FileCreateFlags.REPLACE_DESTINATION, null);
         } catch (Error e) {
             warning ("%s\n", e.message);
         }


### PR DESCRIPTION
Whilst the user interface shows an export button, the function to export was not implemented, these commits will add this and as such all of the contractors function now (print (#129), compress, email (#80), bluetooth, export). Print just prints the text, however that seems to be the expected behaviour based on trying to print ics files from Files. The exported files may contain some errors namely about having no values for certain fields, however this does not impact usage of the ical file.

Fixes #80 
Fixes #129
Fixes #30 