### PR TITLE
Avoid property names "first" and "last".

### DIFF
--- a/core/DateRange.vala
+++ b/core/DateRange.vala
@@ -23,13 +23,13 @@ namespace Maya.Util {
 
         public DateIterator (DateRange range) {
             this.range = range;
-            this.current = range.first.add_days (-1);
+            this.current = range.first_dt.add_days (-1);
         }
 
         public bool @foreach (Gee.ForallFunc<DateTime> f) {
-            var element = range.first;
+            var element = range.first_dt;
 
-            while (element.compare (range.last) < 0) {
+            while (element.compare (range.last_dt) < 0) {
                 if (f (element) == false) {
                     return false;
                 }
@@ -48,11 +48,11 @@ namespace Maya.Util {
         }
 
         public bool has_next() {
-            return current.compare(range.last) < 0;
+            return current.compare(range.last_dt) < 0;
         }
 
         public bool first () {
-            current = range.first;
+            current = range.first_dt;
             return true;
         }
 
@@ -67,8 +67,8 @@ namespace Maya.Util {
 
     /* Represents date range from 'first' to 'last' inclusive */
     public class DateRange : Object, Gee.Traversable<DateTime>, Gee.Iterable<DateTime> {
-        public DateTime first { get; private set; }
-        public DateTime last { get; private set; }
+        public DateTime first_dt { get; private set; }
+        public DateTime last_dt { get; private set; }
         public bool @foreach (Gee.ForallFunc<DateTime> f) {
             foreach (var date in this) {
                 if (f (date) == false) {
@@ -80,20 +80,20 @@ namespace Maya.Util {
         }
 
         public int64 days {
-            get { return last.difference (first) / GLib.TimeSpan.DAY; }
+            get { return last_dt.difference (first_dt) / GLib.TimeSpan.DAY; }
         }
 
         public DateRange (DateTime first, DateTime last) {
-            this.first = first;
-            this.last = last;
+            this.first_dt = first;
+            this.last_dt = last;
         }
 
         public DateRange.copy (DateRange date_range) {
-            this (date_range.first, date_range.last);
+            this (date_range.first_dt, date_range.last_dt);
         }
 
         public bool equals (DateRange other) {
-            return (first==other.first && last==other.last);
+            return (this.first_dt==other.first_dt && this.last_dt==other.last_dt);
         }
 
         public Type element_type {
@@ -105,7 +105,7 @@ namespace Maya.Util {
         }
 
         public bool contains (DateTime time) {
-            return (first.compare (time) < 1) && (last.compare (time) > -1);
+            return (first_dt.compare (time) < 1) && (last_dt.compare (time) > -1);
         }
 
         public Gee.SortedSet<DateTime> to_set() {

--- a/core/Model/CalendarModel.vala
+++ b/core/Model/CalendarModel.vala
@@ -18,7 +18,7 @@ public class Maya.Model.CalendarModel : Object {
      * data. The month_range is a subset of this range corresponding to the
      * calendar month that is being focused on. In summary:
      *
-     * data_range.first <= month_range.first < month_range.last <= data_range.last
+     * data_range.first_dt <= month_range.first_dt < month_range.last_dt <= data_range.last_dt
      *
      * There is no way to set the ranges publicly. They can only be modified by
      * changing one of the following properties: month_start, num_weeks, and
@@ -253,7 +253,7 @@ public class Maya.Model.CalendarModel : Object {
         events_removed (source, events);
         source_events.remove (source);
     }
-    
+
     public Gee.Collection<E.CalComponent> get_events () {
         Gee.ArrayList<E.CalComponent> events = new Gee.ArrayList<E.CalComponent> ();
         registry.list_sources (E.SOURCE_EXTENSION_CALENDAR).foreach ((source) => {
@@ -312,8 +312,8 @@ public class Maya.Model.CalendarModel : Object {
             (Gee.EqualDataFunc<E.CalComponent>?) Util.calcomponent_equal_func);
         source_events.set (source, events);
         // query client view
-        var iso_first = E.Util.isodate_from_time_t ((time_t) data_range.first.to_unix ());
-        var iso_last = E.Util.isodate_from_time_t ((time_t) data_range.last.add_days (1).to_unix ());
+        var iso_first = E.Util.isodate_from_time_t ((time_t) data_range.first_dt.to_unix ());
+        var iso_last = E.Util.isodate_from_time_t ((time_t) data_range.last_dt.add_days (1).to_unix ());
         var query = @"(occur-in-time-range? (make-time \"$iso_first\") (make-time \"$iso_last\"))";
 
         E.CalClient client;
@@ -374,7 +374,7 @@ public class Maya.Model.CalendarModel : Object {
     }
 
     private void on_source_changed (E.Source source) {
-        
+
     }
 
     private void on_objects_added (E.Source source, E.CalClient client, SList<unowned iCal.Component> objects) {

--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -121,10 +121,10 @@ namespace Maya.Util {
             end = end.add_days (-1);
         }
 
-        int c1 = start.compare (view_range.first);
-        int c2 = start.compare (view_range.last);
-        int c3 = end.compare (view_range.first);
-        int c4 = end.compare (view_range.last);
+        int c1 = start.compare (view_range.first_dt);
+        int c2 = start.compare (view_range.last_dt);
+        int c3 = end.compare (view_range.first_dt);
+        int c4 = end.compare (view_range.last_dt);
 
         if (c1 <= 0 && c3 > 0) {
             return true;
@@ -185,8 +185,8 @@ namespace Maya.Util {
             var exdate = property.get_exdate ();
             var date = ical_to_date_time (exdate);
             dateranges.@foreach ((daterange) => {
-                var first = daterange.first;
-                var last = daterange.last;
+                var first = daterange.first_dt;
+                var last = daterange.last_dt;
                 if (first.get_year () <= date.get_year () && last.get_year () >= date.get_year ()) {
                     if (first.get_day_of_year () <= date.get_day_of_year () && last.get_day_of_year () >= date.get_day_of_year ()) {
                         dateranges.remove (daterange);
@@ -220,7 +220,7 @@ namespace Maya.Util {
         } else {
             int i = 1;
             int n = i*rrule.interval;
-            while (view_range.last.compare (start.add_days (n)) > 0) {
+            while (view_range.last_dt.compare (start.add_days (n)) > 0) {
                 dateranges.add (new Util.DateRange (start.add_days (n), end.add_days (n)));
                 i++;
                 n = i*rrule.interval;
@@ -247,7 +247,7 @@ namespace Maya.Util {
             int n = i*rrule.interval;
             bool is_null_time = rrule.until.is_null_time () == 1;
             var temp_start = start.add_years (n);
-            while (view_range.last.compare (temp_start) > 0) {
+            while (view_range.last_dt.compare (temp_start) > 0) {
                 if (is_null_time == false) {
                     if (temp_start.get_year () > rrule.until.year)
                         break;
@@ -255,7 +255,7 @@ namespace Maya.Util {
                         break;
                     else if (temp_start.get_year () == rrule.until.year && temp_start.get_month () == rrule.until.month &&temp_start.get_day_of_month () > rrule.until.day)
                         break;
-                
+
                 }
                 dateranges.add (new Util.DateRange (temp_start, end.add_years (n)));
                 i++;
@@ -287,7 +287,7 @@ namespace Maya.Util {
                     int start_week = (int)GLib.Math.ceil ((double)start.get_day_of_month () / 7);
 
                     // Loop through each individual month from the start and test to see if our event is in the month or not
-                    while (view_range.last.compare (start_ical_day) > 0) {
+                    while (view_range.last_dt.compare (start_ical_day) > 0) {
                         if (is_null_time == false) {
                             if (start_ical_day.get_year () > rrule.until.year)
                                 break;
@@ -300,12 +300,12 @@ namespace Maya.Util {
                         var start_ical_day_new = get_date_from_ical_day (start.add_months (i), rrule.by_day[k]);
                         int month = start.add_months (i).get_month ();
                         int week = start_week;
-                    
+
                         // If event repeats on a last day of the month, take us back a week if we move into a new month
                         if (is_last && start_ical_day_new.get_month () != month) {
                             start_ical_day_new = start_ical_day_new.add_weeks (-1);
                         }
-                        
+
                         else if (!is_last) {
                             if (start_ical_day_new.get_day_of_month () <= 7 && start_ical_day_new.add_weeks (-1).get_month () == month) {
                                 week = 2;
@@ -314,7 +314,7 @@ namespace Maya.Util {
                                 week =  (int)GLib.Math.ceil ((double)start_ical_day_new.get_day_of_month () / 7);
                             }
                         }
-                       
+
                         start_ical_day_new = start_ical_day_new.add_weeks (start_week - week);
                         if (start_ical_day_new.get_month () != month) {
                             start_ical_day = start.add_months (i);
@@ -345,7 +345,7 @@ namespace Maya.Util {
                 int n = i*rrule.interval;
                 bool is_null_time = rrule.until.is_null_time () == 1;
                 var temp_start = start.add_months (n);
-                while (view_range.last.compare (temp_start) > 0) {
+                while (view_range.last_dt.compare (temp_start) > 0) {
                     if (is_null_time == false) {
                         if (temp_start.get_year () > rrule.until.year)
                             break;
@@ -353,7 +353,7 @@ namespace Maya.Util {
                             break;
                         else if (temp_start.get_year () == rrule.until.year && temp_start.get_month () == rrule.until.month && temp_start.get_day_of_month () > rrule.until.day)
                             break;
-                    
+
                     }
 
                     dateranges.add (new Util.DateRange (temp_start, end.add_months (n)));
@@ -415,7 +415,7 @@ namespace Maya.Util {
                 int n = i*rrule.interval*7;
                 bool is_null_time = rrule.until.is_null_time () == 1;
                 var temp_start = start.add_days (n);
-                while (view_range.last.compare (temp_start) > 0) {
+                while (view_range.last_dt.compare (temp_start) > 0) {
                     if (is_null_time == false) {
                         if (temp_start.get_year () > rrule.until.year)
                             break;
@@ -612,7 +612,7 @@ namespace Maya.Util {
 
             T ovalue = gvalue.get_object ();
 
-            if ((eqfunc == null && ovalue == object) 
+            if ((eqfunc == null && ovalue == object)
                     || (eqfunc != null && eqfunc (ovalue, object))) {
                 path = p;
                 return true;

--- a/src/Grid/CalendarView.vala
+++ b/src/Grid/CalendarView.vala
@@ -6,12 +6,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
@@ -122,7 +122,7 @@ public class Maya.View.CalendarView : Gtk.Grid {
 
     void on_show_weeks_changed () {
         var model = Model.CalendarModel.get_default ();
-        weeks.update (model.data_range.first, model.num_weeks);
+        weeks.update (model.data_range.first_dt, model.num_weeks);
         if (Settings.SavedState.get_default ().show_weeks == true) {
             grid.draw_first_line_column (true);
             header.draw_left_border = true;
@@ -174,18 +174,18 @@ public class Maya.View.CalendarView : Gtk.Grid {
     /* Sets the calendar widgets to the date range of the model */
     void sync_with_model () {
         var model = Model.CalendarModel.get_default ();
-        if (grid.grid_range != null && (model.data_range.equals (grid.grid_range) || grid.grid_range.first.compare (model.data_range.first) == 0))
+        if (grid.grid_range != null && (model.data_range.equals (grid.grid_range) || grid.grid_range.first_dt.compare (model.data_range.first_dt) == 0))
             return; // nothing to do
 
         DateTime previous_first = null;
         if (grid.grid_range != null)
-            previous_first = grid.grid_range.first;
+            previous_first = grid.grid_range.first_dt;
 
         big_grid = create_big_grid ();
         stack.add (big_grid);
 
         header.update_columns (model.week_starts_on);
-        weeks.update (model.data_range.first, model.num_weeks);
+        weeks.update (model.data_range.first_dt, model.num_weeks);
         grid.set_range (model.data_range, model.month_start);
 
         // keep focus date on the same day of the month
@@ -195,7 +195,7 @@ public class Maya.View.CalendarView : Gtk.Grid {
         }
 
         if (previous_first != null) {
-            if (previous_first.compare (grid.grid_range.first) == -1) {
+            if (previous_first.compare (grid.grid_range.first_dt) == -1) {
                 stack.transition_type = Gtk.StackTransitionType.SLIDE_UP;
             } else {
                 stack.transition_type = Gtk.StackTransitionType.SLIDE_DOWN;


### PR DESCRIPTION
Fixes #143 

It appears that the property names XXX_FIRST_PROPERTY and XXX_LAST_PROPERTY are already used by the compiler; use of "first" and "last" as property names in Vala code then produces the error shown in the linked issue.

This was fixed by changing these property names in the vala code.