### PR TITLE
Allow setting location using map

### DIFF
--- a/src/EventEdition/LocationPanel.vala
+++ b/src/EventEdition/LocationPanel.vala
@@ -201,6 +201,7 @@ public class Maya.View.EventEdition.LocationPanel : Gtk.Grid {
         find_cancellable = new GLib.Cancellable ();
         Geocode.Location location = new Geocode.Location (latitude, longitude);
         var reverse = new Geocode.Reverse.for_location (location);
+        
         try {
             var address = yield reverse.resolve_async (find_cancellable);
             var builder = new StringBuilder ();

--- a/src/EventEdition/LocationPanel.vala
+++ b/src/EventEdition/LocationPanel.vala
@@ -207,34 +207,28 @@ public class Maya.View.EventEdition.LocationPanel : Gtk.Grid {
             var builder = new StringBuilder ();
             if (address.street != null) {
                 builder.append (address.street);
-                if (address.town != null) {
-                    builder.append (", ");
-                    builder.append (address.town);
-                }
-                if (address.county != null) {
-                    builder.append (", ");
-                    builder.append (address.county);
-                }
-                if (address.postal_code != null) {
-                    builder.append (", ");
-                    builder.append (address.postal_code);
-                }
-                if (address.country != null) {
-                    builder.append (", ");
-                    builder.append (address.country);
-                }
+                add_address_line (builder, address.town);
+                add_address_line (builder, address.county);
+                add_address_line (builder, address.postal_code);
+                add_address_line (builder, address.country);
             } else {
                 builder.append (address.name);
-                if (address.country != null) {
-                    builder.append (", ");
-                    builder.append (address.country);
-                }
+                add_address_line (builder, address.country);
             }
+            
             location_entry.text = builder.str;
         } catch (Error error) {
             debug (error.message);
         }
     }
+    
+    private void add_address_line (StringBuilder sb, string? text) {
+        if (text != null) {
+             sb.append (", ");
+             sb.append (text);
+        }
+    }
+
     
     /**
      * Filter all contacts with address information and

--- a/src/EventEdition/LocationPanel.vala
+++ b/src/EventEdition/LocationPanel.vala
@@ -132,6 +132,9 @@ public class Maya.View.EventEdition.LocationPanel : Gtk.Grid {
         destroy.connect (() => {
             if (search_cancellable != null)
                 search_cancellable.cancel ();
+            if (find_cancellable != null) {
+                find_cancellable.cancel ();
+            }
         });
     }
 
@@ -191,8 +194,11 @@ public class Maya.View.EventEdition.LocationPanel : Gtk.Grid {
     }
 
     private async void find_location (double latitude, double longitude) {
-        if (find_cancellable != null)
+        if (find_cancellable != null) {
             find_cancellable.cancel ();
+        }
+        
+        find_cancellable = new GLib.Cancellable ();
         Geocode.Location location = new Geocode.Location (latitude, longitude);
         var reverse = new Geocode.Reverse.for_location (location);
         try {
@@ -216,8 +222,7 @@ public class Maya.View.EventEdition.LocationPanel : Gtk.Grid {
                     builder.append (", ");
                     builder.append (address.country);
                 }
-            }
-            else {
+            } else {
                 builder.append (address.name);
                 if (address.country != null) {
                     builder.append (", ");


### PR DESCRIPTION
The map currently only displays the location found from the search bar and does not allow setting location through it. This problem was raised by issue #53; as double clicking is used to zoom, I agree with Steffen that the logical method is through dragging. This push will implement this, however note this will not use the exact way which would be through latitude and longitude but rather reverse geocodes to get an address as I think that is a better way of representing the location to the user, even if it loses some accuracy.