### PR TITLE
Avoid garbled text and crash in Location Panel.

### DIFF
--- a/src/EventEdition/LocationPanel.vala
+++ b/src/EventEdition/LocationPanel.vala
@@ -6,12 +6,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
@@ -64,8 +64,9 @@ public class Maya.View.EventEdition.LocationPanel : Gtk.Grid {
             model.get_value (iter, 0, out val1);
             model.get_value (iter, 1, out val2);
 
-            if (val1.get_string ().casefold (-1).contains (key) || val2.get_string ().casefold (-1).contains (key)) 
+            if (val1.get_string ().casefold (-1).contains (key) || val2.get_string ().casefold (-1).contains (key)) {
                 return true;
+            }
 
             return false;
         });
@@ -94,10 +95,12 @@ public class Maya.View.EventEdition.LocationPanel : Gtk.Grid {
         });
 
         if (parent_dialog.ecal != null) {
-            string location;
-            parent_dialog.ecal.get_location (out location);
-            if (location != null)
-                location_entry.text = location;
+            unowned iCal.Component comp = parent_dialog.ecal.get_icalcomponent ();
+            unowned string location = comp.get_location ();
+
+            if (location != null) {
+                location_entry.text = location.dup ();
+            }
 
             iCal.GeoType? geo;
             parent_dialog.ecal.get_geo (out geo);
@@ -187,7 +190,7 @@ public class Maya.View.EventEdition.LocationPanel : Gtk.Grid {
             debug (error.message);
         }
     }
-    
+
     /**
      * Filter all contacts with address information and
      * add them to the location store.
@@ -202,7 +205,7 @@ public class Maya.View.EventEdition.LocationPanel : Gtk.Grid {
             }
         }
     }
-    
+
     /**
      * Load the backend and call add_contacts_store with all
      * contacts.


### PR DESCRIPTION
see #42 

TO TEST:

1) Open an event with a location set; open Location tab.
2) Cancel
3) Repeat 1) and 2)

In trunk the location entry text becomes garbled and the app may crash.
In branch the entry text is correct each time.