### PR TITLE
Add infobar to MainWindow

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -125,6 +125,10 @@ namespace Maya {
             window.default_width = saved_state.window_width;
             window.default_height = saved_state.window_height;
 
+            if (saved_state.window_state == Settings.WindowState.MAXIMIZED) {
+                window.maximize ();
+            }
+
             window.delete_event.connect (on_window_delete_event);
             window.destroy.connect (on_quit);
 
@@ -164,35 +168,9 @@ namespace Maya {
             hpaned.pack2 (sidebar, true, false);
             hpaned.position = saved_state.hpaned_position;
 
-            var infobar_label = new Gtk.Label (null);
-            infobar_label.show ();
-
-            var infobar = new Gtk.InfoBar ();
-            infobar.message_type = Gtk.MessageType.ERROR;
-            infobar.show_close_button = true;
-            infobar.get_content_area ().add (infobar_label);
-            infobar.no_show_all = true;
-            infobar.response.connect ((id) => infobar.hide ());
-
-            Model.CalendarModel.get_default ().error_received.connect ((message) => {
-                Idle.add (() => {
-                    infobar_label.label = message;
-                    infobar.show ();
-                    return false;
-                });
-            });
-
-            var gridcontainer = new Gtk.Grid ();
-            gridcontainer.orientation = Gtk.Orientation.VERTICAL;
-            gridcontainer.add (infobar);
-            gridcontainer.add (hpaned);
-
-            window.add (gridcontainer);
+            window.grid.add (hpaned);
 
             add_window (window);
-
-            if (saved_state.window_state == Settings.WindowState.MAXIMIZED)
-                window.maximize ();
         }
 
         /**

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -20,6 +20,8 @@
  */
 
 public class Maya.MainWindow : Gtk.ApplicationWindow {
+    public Gtk.Grid grid;
+
     public MainWindow (Gtk.Application application) {
         Object (
             application: application,
@@ -32,5 +34,30 @@ public class Maya.MainWindow : Gtk.ApplicationWindow {
     construct {
         weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_default ();
         default_theme.add_resource_path ("/org/pantheon/maya");
+
+        var infobar_label = new Gtk.Label (null);
+        infobar_label.show ();
+
+        var infobar = new Gtk.InfoBar ();
+        infobar.message_type = Gtk.MessageType.ERROR;
+        infobar.no_show_all = true;
+        infobar.show_close_button = true;
+        infobar.get_content_area ().add (infobar_label);
+
+        grid = new Gtk.Grid ();
+        grid.orientation = Gtk.Orientation.VERTICAL;
+        grid.add (infobar);
+
+        add (grid);
+
+        infobar.response.connect ((id) => infobar.hide ());
+
+        Model.CalendarModel.get_default ().error_received.connect ((message) => {
+            Idle.add (() => {
+                infobar_label.label = message;
+                infobar.show ();
+                return false;
+            });
+        });
     }
 }


### PR DESCRIPTION
Making the grid public is only temporary in order to transition pieces into MainWindow a bit at a time

* move a state restoring conditional up with other state restoring code
* Move the infobar into MainWindow