### PR TITLE
Correct FSF address

### DIFF
--- a/core/Backends/Backend.vala
+++ b/core/Backends/Backend.vala
@@ -14,8 +14,8 @@
  *
  * You should have received a copy of the GNU Library General Public
  * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
  *
  * Authored by: Corentin Noël <tintou@mailoo.org>
  */

--- a/core/Backends/BackendsManager.vala
+++ b/core/Backends/BackendsManager.vala
@@ -14,8 +14,8 @@
  *
  * You should have received a copy of the GNU Library General Public
  * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
  *
  * Authored by: Corentin Noël <tintou@mailoo.org>
  */

--- a/core/Backends/LocalBackend.vala
+++ b/core/Backends/LocalBackend.vala
@@ -14,8 +14,8 @@
  *
  * You should have received a copy of the GNU Library General Public
  * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
  *
  * Authored by: Corentin Noël <tintou@mailoo.org>
  */

--- a/core/Backends/PlacementWidget.vala
+++ b/core/Backends/PlacementWidget.vala
@@ -14,8 +14,8 @@
  *
  * You should have received a copy of the GNU Library General Public
  * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
  *
  * Authored by: Corentin Noël <tintou@mailoo.org>
  */

--- a/plugins/CalDAV/CalDAVBackend.vala
+++ b/plugins/CalDAV/CalDAVBackend.vala
@@ -14,8 +14,8 @@
  *
  * You should have received a copy of the GNU Library General Public
  * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
  *
  * Authored by: Corentin Noël <tintou@mailoo.org>
  */

--- a/plugins/Google/GoogleBackend.vala
+++ b/plugins/Google/GoogleBackend.vala
@@ -14,8 +14,8 @@
  *
  * You should have received a copy of the GNU Library General Public
  * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
  *
  * Authored by: Corentin Noël <tintou@mailoo.org>
  */


### PR DESCRIPTION
This corrects the address for the Free Software Foundation in the LGPL license headers. I had previously had submitted this in #148 but since it is a small, simple change I decided to separate it out.

Fixes #101