### PR TITLE
Sort events on Grid

### DIFF
--- a/src/Grid/EventButton.vala
+++ b/src/Grid/EventButton.vala
@@ -104,15 +104,4 @@ public class Maya.View.EventButton : Gtk.Revealer {
         rgba.parse (color);
         event_box.override_background_color (Gtk.StateFlags.NORMAL, rgba);
     }
-
-    /**
-     * Compares the given buttons according to date.
-     */
-    public static GLib.CompareDataFunc<Maya.View.EventButton>? compare_buttons = (button1, button2) => {
-        var comp1 = button1.comp;
-        var comp2 = button2.comp;
-
-        return Util.compare_events (comp1, comp2);
-    };
-
 }

--- a/src/Grid/VAutoHider.vala
+++ b/src/Grid/VAutoHider.vala
@@ -38,10 +38,31 @@ namespace Maya.View {
         }
 
         public override void add (Gtk.Widget widget) {
+            List<weak Gtk.Widget> children = main_box.get_children ();
+            children.append (widget);
+        
+            children.sort ((a, b) => {
+                EventButton a2 = a as EventButton;
+                EventButton b2 = b as EventButton;
+                
+                if (a2 == null) {
+                    return 1;
+                } else if (b2 == null) {
+                    return 0;
+                } else {
+                    return Util.compare_events (a2.comp, b2.comp);
+                }
+            });
+            
+            int index = children.index (widget);
+            
             main_box.add (widget);
+            main_box.reorder_child (widget, index);
+            
             widget.destroy.connect (() => {
                 queue_resize ();
             });
+            
             queue_resize ();
         }
 
@@ -124,7 +145,7 @@ namespace Maya.View {
             revealer.transition_duration = reveal_duration;
             revealer.show ();
         }
-
+        
         public override void get_preferred_width (out int minimum_width, out int natural_width) {
             base.get_preferred_width (out minimum_width, out natural_width);
             more_label.get_preferred_width (out minimum_width, null);

--- a/src/Grid/VAutoHider.vala
+++ b/src/Grid/VAutoHider.vala
@@ -55,7 +55,6 @@ namespace Maya.View {
             });
             
             int index = children.index (widget);
-            
             main_box.add (widget);
             main_box.reorder_child (widget, index);
             
@@ -145,7 +144,7 @@ namespace Maya.View {
             revealer.transition_duration = reveal_duration;
             revealer.show ();
         }
-        
+
         public override void get_preferred_width (out int minimum_width, out int natural_width) {
             base.get_preferred_width (out minimum_width, out natural_width);
             more_label.get_preferred_width (out minimum_width, null);


### PR DESCRIPTION
This sorts the events on the grid according to the Util.compare_events function (it moves non-EventButtons to the end as the only one of those should be the show more label) .

Fixes #94