### PR TITLE
Update EventButtons directly

### DIFF
--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -144,6 +144,17 @@ namespace Maya.Util {
 
         return false;
     }
+    
+    public bool is_day_in_range (DateTime day, Util.DateRange range) {
+        var date = day.get_day_of_year ();
+        
+        foreach (var dt in range) {
+            if (dt.get_day_of_year () == date && dt.get_year () == day.get_year ()) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     public Gee.Collection<DateRange> event_date_ranges (iCal.Component comp, Util.DateRange view_range) {
         var dateranges = new Gee.LinkedList<DateRange> ();

--- a/src/Grid/CalendarView.vala
+++ b/src/Grid/CalendarView.vala
@@ -213,8 +213,7 @@ public class Maya.View.CalendarView : Gtk.Grid {
 
     /* Update the event on the grid */
     void update_event (E.Source source, E.CalComponent event) {
-        remove_event (source, event);
-        add_event (source, event);
+        grid.update_event (event);
     }
 
     /* Remove event from the grid */

--- a/src/Grid/EventButton.vala
+++ b/src/Grid/EventButton.vala
@@ -95,6 +95,11 @@ public class Maya.View.EventButton : Gtk.Revealer {
         set_color (cal.dup_color ());
     }
 
+    public void update (E.CalComponent event) {
+       this.comp = comp;
+       label.label = get_summary ();
+    }
+
     public string get_summary () {
         return comp.get_summary ().value;
     }

--- a/src/Grid/Grid.vala
+++ b/src/Grid/Grid.vala
@@ -226,17 +226,21 @@ public class Grid : Gtk.Grid {
 
     public void update_event (E.CalComponent event) {
         Gee.Collection<Util.DateRange> event_ranges = Util.event_date_ranges (event.get_icalcomponent (), grid_range);
+
         foreach (var grid_day in data.values) {
             bool contains = false;
+
             foreach (Util.DateRange event_range in event_ranges) {
                 if (Util.is_day_in_range (grid_day.date, event_range)) {
                     contains = true;
                 }
             }
+
             if (contains) {
                 if (!grid_day.update_event (event)) {
                     EventButton button = new EventButton (event);
                     add_button_for_day (grid_day.date, button);
+
                     button.edition_request.connect (() => {
                         edition_request (event);
                     });

--- a/src/Grid/Grid.vala
+++ b/src/Grid/Grid.vala
@@ -225,8 +225,25 @@ public class Grid : Gtk.Grid {
     }
 
     public void update_event (E.CalComponent event) {
+        Gee.Collection<Util.DateRange> event_ranges = Util.event_date_ranges (event.get_icalcomponent (), grid_range);
         foreach (var grid_day in data.values) {
-            grid_day.update_event (event);
+            bool contains = false;
+            foreach (Util.DateRange event_range in event_ranges) {
+                if (event_range.contains (grid_day.date)) {
+                    contains = true;
+                }
+            }
+            if (contains) {
+                if (!grid_day.update_event (event)) {
+                    EventButton button = new EventButton (event);
+                    add_button_for_day (grid_day.date, button);
+                    button.edition_request.connect (() => {
+                        edition_request (event);
+                    });
+                }
+            } else {
+                grid_day.remove_event (event);
+            }
         }
     }
 

--- a/src/Grid/Grid.vala
+++ b/src/Grid/Grid.vala
@@ -224,6 +224,12 @@ public class Grid : Gtk.Grid {
         }
     }
 
+    public void update_event (E.CalComponent event) {
+        foreach (var grid_day in data.values) {
+            grid_day.update_event (event);
+        }
+    }
+
     /**
      * Removes all events from the grid.
      */

--- a/src/Grid/Grid.vala
+++ b/src/Grid/Grid.vala
@@ -229,7 +229,7 @@ public class Grid : Gtk.Grid {
         foreach (var grid_day in data.values) {
             bool contains = false;
             foreach (Util.DateRange event_range in event_ranges) {
-                if (event_range.contains (grid_day.date)) {
+                if (Util.is_day_in_range (grid_day.date, event_range)) {
                     contains = true;
                 }
             }

--- a/src/Grid/GridDay.vala
+++ b/src/Grid/GridDay.vala
@@ -145,6 +145,17 @@ public class Maya.View.GridDay : Gtk.EventBox {
 
     }
 
+    public void update_event (E.CalComponent comp) {
+        unowned iCal.Component calcomp = comp.get_icalcomponent ();
+        string uid = calcomp.get_uid ();
+        lock (event_buttons) {
+            var button = event_buttons.get (uid);
+            if (button != null) {
+                button.update (comp);
+            }
+        }
+    }
+
     public void remove_event (E.CalComponent comp) {
         unowned iCal.Component calcomp = comp.get_icalcomponent ();
         string uid = calcomp.get_uid ();

--- a/src/Grid/GridDay.vala
+++ b/src/Grid/GridDay.vala
@@ -153,6 +153,7 @@ public class Maya.View.GridDay : Gtk.EventBox {
             var button = event_buttons.get (uid);
             if (button != null) {
                 button.update (comp);
+                event_box.update (button);
             } else {
                 return false;
             }

--- a/src/Grid/GridDay.vala
+++ b/src/Grid/GridDay.vala
@@ -148,6 +148,7 @@ public class Maya.View.GridDay : Gtk.EventBox {
     public bool update_event (E.CalComponent comp) {
         unowned iCal.Component calcomp = comp.get_icalcomponent ();
         string uid = calcomp.get_uid ();
+
         lock (event_buttons) {
             var button = event_buttons.get (uid);
             if (button != null) {
@@ -156,6 +157,7 @@ public class Maya.View.GridDay : Gtk.EventBox {
                 return false;
             }
         }
+
         return true;
     }
 

--- a/src/Grid/GridDay.vala
+++ b/src/Grid/GridDay.vala
@@ -145,15 +145,18 @@ public class Maya.View.GridDay : Gtk.EventBox {
 
     }
 
-    public void update_event (E.CalComponent comp) {
+    public bool update_event (E.CalComponent comp) {
         unowned iCal.Component calcomp = comp.get_icalcomponent ();
         string uid = calcomp.get_uid ();
         lock (event_buttons) {
             var button = event_buttons.get (uid);
             if (button != null) {
                 button.update (comp);
+            } else {
+                return false;
             }
         }
+        return true;
     }
 
     public void remove_event (E.CalComponent comp) {

--- a/src/Grid/VAutoHider.vala
+++ b/src/Grid/VAutoHider.vala
@@ -40,28 +40,17 @@ namespace Maya.View {
         public override void add (Gtk.Widget widget) {
             List<weak Gtk.Widget> children = main_box.get_children ();
             children.append (widget);
-        
-            children.sort ((a, b) => {
-                EventButton a2 = a as EventButton;
-                EventButton b2 = b as EventButton;
-                
-                if (a2 == null) {
-                    return 1;
-                } else if (b2 == null) {
-                    return 0;
-                } else {
-                    return Util.compare_events (a2.comp, b2.comp);
-                }
-            });
-            
+
+            children.sort (compare_children);
+
             int index = children.index (widget);
             main_box.add (widget);
             main_box.reorder_child (widget, index);
-            
+
             widget.destroy.connect (() => {
                 queue_resize ();
             });
-            
+
             queue_resize ();
         }
 
@@ -158,6 +147,27 @@ namespace Maya.View {
             if (minimum_height > natural_height)
                 natural_height = minimum_height;
         }
+
+        public void update (Gtk.Widget widget) {
+            List<weak Gtk.Widget> children = main_box.get_children ();
+
+            children.sort (compare_children);
+            int index = children.index (widget);
+            main_box.reorder_child (widget, index);
+        }
+
+        public static GLib.CompareFunc<weak Gtk.Widget> compare_children = (a, b) => {
+            EventButton a2 = a as EventButton;
+            EventButton b2 = b as EventButton;
+
+            if (a2 == null) {
+                return 1;
+            } else if (b2 == null) {
+                return 0;
+            } else {
+                return Util.compare_events (a2.comp, b2.comp);
+            }
+        };
 
     }
 }


### PR DESCRIPTION
This replaces the remove and re-add behaviour for updating events and directly updates the event on the button. As a result there is no duplication on the event whilst this is going on. This does add quite a bit of complexity when handling multi-day events.

Fixes #127 