### PR TITLE
Correct selecting days in other months

### DIFF
--- a/data/style/calendar.css
+++ b/data/style/calendar.css
@@ -18,7 +18,6 @@
 
 @define-color cell_color mix(@bg_color, rgb(255, 255, 255), 0.5);
 @define-color text_color #333;
-@define-color alt_text_color #AEADAE;
 
 /* Header Styles */
 
@@ -38,7 +37,6 @@
 
 .other_month {
     background-color: shade(@cell_color, 0.97);
-    color: @alt_text_color;
 }
 
 .cell:selected {

--- a/data/style/calendar.css
+++ b/data/style/calendar.css
@@ -18,6 +18,7 @@
 
 @define-color cell_color mix(@bg_color, rgb(255, 255, 255), 0.5);
 @define-color text_color #333;
+@define-color alt_text_color #AEADAE;
 
 /* Header Styles */
 
@@ -35,8 +36,9 @@
     border-radius: 0;
 }
 
-.cell:insensitive {
-	background-color: shade(@cell_color, 0.97);
+.other_month {
+    background-color: shade(@cell_color, 0.97);
+    color: @alt_text_color;
 }
 
 .cell:selected {

--- a/src/Grid/Grid.vala
+++ b/src/Grid/Grid.vala
@@ -158,11 +158,7 @@ public class Grid : Gtk.Grid {
             day.name = "today";
         }
 
-        if (new_date.get_month () == month_start.get_month ()) {
-            day.set_current_month (true);
-        } else {
-            day.set_current_month (false);
-        }
+        day.in_current_month = new_date.get_month () == month_start.get_month ();
 
         day.update_date (new_date);
         return day;

--- a/src/Grid/Grid.vala
+++ b/src/Grid/Grid.vala
@@ -159,9 +159,9 @@ public class Grid : Gtk.Grid {
         }
 
         if (new_date.get_month () == month_start.get_month ()) {
-            day.sensitive_container (true);
+            day.set_current_month (true);
         } else {
-            day.sensitive_container (false);
+            day.set_current_month (false);
         }
 
         day.update_date (new_date);

--- a/src/Grid/GridDay.vala
+++ b/src/Grid/GridDay.vala
@@ -173,8 +173,8 @@ public class Maya.View.GridDay : Gtk.EventBox {
         });
     }
 
-    public void set_current_month (bool sens) {
-        if (sens) {
+    public void set_current_month (bool current) {
+        if (current) {
             get_style_context ().remove_class ("other_month");
         } else {
             get_style_context ().add_class ("other_month");

--- a/src/Grid/GridDay.vala
+++ b/src/Grid/GridDay.vala
@@ -37,6 +37,16 @@ public class Maya.View.GridDay : Gtk.EventBox {
     VAutoHider event_box;
     GLib.HashTable<string, EventButton> event_buttons;
 
+    public bool in_current_month {
+        set {
+            if (value) {
+                get_style_context ().remove_class ("other_month");
+            } else {
+                get_style_context ().add_class ("other_month");
+            }
+        }
+    }
+
     private const int EVENT_MARGIN = 3;
 
     public GridDay (DateTime date) {
@@ -188,14 +198,6 @@ public class Maya.View.GridDay : Gtk.EventBox {
             button.destroy ();
             return false;
         });
-    }
-
-    public void set_current_month (bool current) {
-        if (current) {
-            get_style_context ().remove_class ("other_month");
-        } else {
-            get_style_context ().add_class ("other_month");
-        }
     }
 
     public void update_date (DateTime date) {

--- a/src/Grid/GridDay.vala
+++ b/src/Grid/GridDay.vala
@@ -41,8 +41,10 @@ public class Maya.View.GridDay : Gtk.EventBox {
         set {
             if (value) {
                 get_style_context ().remove_class ("other_month");
+                get_style_context ().remove_class (Gtk.STYLE_CLASS_DIM_LABEL);
             } else {
                 get_style_context ().add_class ("other_month");
+                get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
             }
         }
     }

--- a/src/Grid/GridDay.vala
+++ b/src/Grid/GridDay.vala
@@ -173,8 +173,12 @@ public class Maya.View.GridDay : Gtk.EventBox {
         });
     }
 
-    public void sensitive_container (bool sens) {
-        container_grid.sensitive = sens;
+    public void set_current_month (bool sens) {
+        if (sens) {
+            get_style_context ().remove_class ("other_month");
+        } else {
+            get_style_context ().add_class ("other_month");
+        }
     }
 
     public void update_date (DateTime date) {


### PR DESCRIPTION
Previously GridDays in other months were marked as insensitive, this caused issues when clicking on them and required you to click at the very top (the label) to change month, this resolves this by instead using a css class to style cells that are in other months. A side effect of this push is that the background colour for other months applies, whereas previously the css that should have been applied was not, if this is not a desired result, that rule can easily be removed to just be the grayed out text.

![screenshot from 2017-10-08 00 06 03](https://user-images.githubusercontent.com/18336287/31312504-2cba3cd0-abbd-11e7-8acd-267a7dbb0b6e.png)

Fixes #74 