### PR TITLE
Load non-standard ports when editing

### DIFF
--- a/plugins/CalDAV/CalDAVBackend.vala
+++ b/plugins/CalDAV/CalDAVBackend.vala
@@ -74,7 +74,11 @@ public class Maya.CalDavBackend : GLib.Object, Maya.Backend {
         if (to_edit != null) {
             E.SourceWebdav webdav = (E.SourceWebdav)to_edit.get_extension (E.SOURCE_EXTENSION_WEBDAV_BACKEND);
             var uri = webdav.dup_soup_uri ();
-            ((Gtk.Entry)url_entry.widget).text = "%s://%s%s".printf (uri.get_scheme (), uri.get_host (), uri.get_path ());
+            if (uri.get_port () != 80) {
+                ((Gtk.Entry)url_entry.widget).text = "%s://%s:%u%s".printf (uri.get_scheme (), uri.get_host (), uri.get_port (), uri.get_path ());
+            } else {
+                ((Gtk.Entry)url_entry.widget).text = "%s://%s%s".printf (uri.get_scheme (), uri.get_host (), uri.get_path ());
+            }
         }
 
         /*var find_button = new PlacementWidget ();


### PR DESCRIPTION
When loading a CalDav calendar to edit, it strips the port, so if the user saves a change it will also remove the non-standard port. This shows the port if it is not 80.

Fixes #140 
Fixes #37 