### PR TITLE
Allow right clicking EventButtons

### DIFF
--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -445,8 +445,6 @@ public class Maya.View.AgendaView : Gtk.Grid {
         private Gtk.Label datatime_label;
         private Gtk.Label location_label;
 
-        private Gtk.Menu menu;
-
         private bool isUpcoming;
 
         public AgendaEventRow (E.Source source, E.CalComponent calevent, bool isUpcoming) {
@@ -521,16 +519,21 @@ public class Maya.View.AgendaView : Gtk.Grid {
             if (event.type == Gdk.EventType.@2BUTTON_PRESS) {
                  modified (calevent);
             } else if (event.type == Gdk.EventType.BUTTON_PRESS && event.button == Gdk.BUTTON_SECONDARY) {
-                if (menu == null) {
-                    menu = new Gtk.Menu ();
-                    menu.attach_to_widget (this, null);
-                    var edit_item = new Gtk.MenuItem.with_label (_("Edit…"));
-                    var remove_item = new Gtk.MenuItem.with_label (_("Remove"));
-                    edit_item.activate.connect (() => { modified (calevent); });
-                    remove_item.activate.connect (() => { removed (calevent); });
-                    menu.append (edit_item);
-                    menu.append (remove_item);
+                Gtk.Menu menu = new Gtk.Menu ();
+                menu.attach_to_widget (this, null);
+                var edit_item = new Gtk.MenuItem.with_label (_("Edit…"));
+                var remove_item = new Gtk.MenuItem.with_label (_("Remove"));
+                edit_item.activate.connect (() => { modified (calevent); });
+                remove_item.activate.connect (() => { removed (calevent); });
+
+                E.Source src = calevent.get_data ("source");
+                if (src.writable != true && Model.CalendarModel.get_default ().calclient_is_readonly (src) != false) {
+                    edit_item.sensitive = false;
+                    remove_item.sensitive = false;
                 }
+
+                menu.append (edit_item);
+                menu.append (remove_item);
 
                 menu.popup (null, null, null, event.button, event.time);
                 menu.show_all ();

--- a/src/Grid/EventButton.vala
+++ b/src/Grid/EventButton.vala
@@ -53,10 +53,17 @@ public class Maya.View.EventButton : Gtk.Revealer {
                 edit_event ();
             } else if (event.type == Gdk.EventType.BUTTON_PRESS && event.button == Gdk.BUTTON_SECONDARY) {
                 if (menu == null) {
+                    E.Source src = comp.get_data ("source");
+
                     menu = new Gtk.Menu ();
                     menu.attach_to_widget (this, null);
                     var edit_item = new Gtk.MenuItem.with_label (_("Edit…"));
                     var remove_item = new Gtk.MenuItem.with_label (_("Remove"));
+                    if (src.writable != true && Model.CalendarModel.get_default ().calclient_is_readonly (src) != false) {
+                        edit_item.sensitive = false;
+                        remove_item.sensitive = false;
+                    }
+
                     edit_item.activate.connect (() => { edit_event (); });
                     remove_item.activate.connect (() => { remove_event (); });
                     menu.append (edit_item);

--- a/src/Grid/EventButton.vala
+++ b/src/Grid/EventButton.vala
@@ -27,7 +27,6 @@ public class Maya.View.EventButton : Gtk.Revealer {
     public E.CalComponent comp {get; private set;}
     private Gtk.EventBox event_box;
     private Gtk.Grid internal_grid;
-    private Gtk.Menu menu;
     Gtk.Label label;
 
     public EventButton (E.CalComponent comp) {
@@ -52,23 +51,22 @@ public class Maya.View.EventButton : Gtk.Revealer {
             if (event.type == Gdk.EventType.2BUTTON_PRESS && event.button == Gdk.BUTTON_PRIMARY) {
                 edit_event ();
             } else if (event.type == Gdk.EventType.BUTTON_PRESS && event.button == Gdk.BUTTON_SECONDARY) {
-                if (menu == null) {
-                    E.Source src = comp.get_data ("source");
+                E.Source src = comp.get_data ("source");
+                Gtk.Menu menu = new Gtk.Menu ();
+                menu.attach_to_widget (this, null);
 
-                    menu = new Gtk.Menu ();
-                    menu.attach_to_widget (this, null);
-                    var edit_item = new Gtk.MenuItem.with_label (_("Edit…"));
-                    var remove_item = new Gtk.MenuItem.with_label (_("Remove"));
-                    if (src.writable != true && Model.CalendarModel.get_default ().calclient_is_readonly (src) != false) {
-                        edit_item.sensitive = false;
-                        remove_item.sensitive = false;
-                    }
+                var edit_item = new Gtk.MenuItem.with_label (_("Edit…"));
+                var remove_item = new Gtk.MenuItem.with_label (_("Remove"));
 
-                    edit_item.activate.connect (() => { edit_event (); });
-                    remove_item.activate.connect (() => { remove_event (); });
-                    menu.append (edit_item);
-                    menu.append (remove_item);
+                if (src.writable != true && Model.CalendarModel.get_default ().calclient_is_readonly (src) != false) {
+                    edit_item.sensitive = false;
+                    remove_item.sensitive = false;
                 }
+
+                edit_item.activate.connect (() => { edit_event (); });
+                remove_item.activate.connect (() => { remove_event (); });
+                menu.append (edit_item);
+                menu.append (remove_item);
 
                 menu.popup (null, null, null, event.button, event.time);
                 menu.show_all ();
@@ -129,17 +127,11 @@ public class Maya.View.EventButton : Gtk.Revealer {
     }
 
     private void edit_event () {
-        E.Source src = comp.get_data ("source");
-        if (src.writable == true && Model.CalendarModel.get_default ().calclient_is_readonly (src) == false) {
-            edition_request ();
-        }
+        edition_request ();
     }
 
     private void remove_event () {
-        E.Source src = comp.get_data ("source");
-        if (src.writable == true && Model.CalendarModel.get_default ().calclient_is_readonly (src) == false) {
-            var calmodel = Model.CalendarModel.get_default ();
-            calmodel.remove_event (comp.get_data<E.Source> ("source"), comp, E.CalObjModType.ALL);
-        }
+        var calmodel = Model.CalendarModel.get_default ();
+        calmodel.remove_event (comp.get_data<E.Source> ("source"), comp, E.CalObjModType.ALL);
     }
 }

--- a/src/Grid/EventButton.vala
+++ b/src/Grid/EventButton.vala
@@ -49,7 +49,7 @@ public class Maya.View.EventButton : Gtk.Revealer {
         event_box.add (internal_grid);
         event_box.button_press_event.connect ((event) => {
             if (event.type == Gdk.EventType.2BUTTON_PRESS && event.button == Gdk.BUTTON_PRIMARY) {
-                edit_event ();
+                edition_request ();
             } else if (event.type == Gdk.EventType.BUTTON_PRESS && event.button == Gdk.BUTTON_SECONDARY) {
                 E.Source src = comp.get_data ("source");
                 Gtk.Menu menu = new Gtk.Menu ();
@@ -63,7 +63,7 @@ public class Maya.View.EventButton : Gtk.Revealer {
                     remove_item.sensitive = false;
                 }
 
-                edit_item.activate.connect (() => { edit_event (); });
+                edit_item.activate.connect (() => { edition_request (); });
                 remove_item.activate.connect (() => { remove_event (); });
                 menu.append (edit_item);
                 menu.append (remove_item);
@@ -124,10 +124,6 @@ public class Maya.View.EventButton : Gtk.Revealer {
         var rgba = Gdk.RGBA();
         rgba.parse (color);
         event_box.override_background_color (Gtk.StateFlags.NORMAL, rgba);
-    }
-
-    private void edit_event () {
-        edition_request ();
     }
 
     private void remove_event () {


### PR DESCRIPTION
This adds the ability to right click events on the grid to edit or remove them, this matches the behaviour of right clicking events in the agenda view.