### PR TITLE
Show event repeats in agenda correctly

### DIFF
--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -114,18 +114,24 @@ public class Maya.View.AgendaView : Gtk.Grid {
         });
 
         selected_date_events_list.set_filter_func ((row) => {
-            var event_row = (AgendaEventRow) row;
-            if (selected_date == null)
+            if (selected_date == null) {
                 return false;
+            }
 
+            var event_row = (AgendaEventRow) row;
             unowned iCal.Component comp = event_row.calevent.get_icalcomponent ();
-            DateTime start_date, end_date;
-            Util.get_local_datetimes_from_icalcomponent (comp, out start_date, out end_date);
 
             var stripped_time = new DateTime.local (selected_date.get_year (), selected_date.get_month (), selected_date.get_day_of_month (), 0, 0, 0);
             var range = new Util.DateRange (stripped_time, stripped_time.add_days (1));
+            Gee.Collection<Util.DateRange> event_ranges = Util.event_date_ranges (comp, range);
 
-            return Util.is_event_in_range (comp, range);
+            foreach (Util.DateRange event_range in event_ranges) {
+                if (Util.is_day_in_range (stripped_time, event_range)) {
+                    return true;
+                }
+            }
+
+            return false;
         });
 
         var selected_scrolled = new Gtk.ScrolledWindow (null, null);


### PR DESCRIPTION
This changes the filter for the selected date events list in agenda to correctly handle repeating events.

Fixes #181 