### PR TITLE
Handle null dtends correctly

### DIFF
--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -107,9 +107,17 @@ namespace Maya.Util {
     public void get_local_datetimes_from_icalcomponent (iCal.Component comp, out DateTime start_date, out DateTime end_date) {
         iCal.TimeType dt_start = comp.get_dtstart ();
         iCal.TimeType dt_end = comp.get_dtend ();
-
         start_date = Util.ical_to_date_time (dt_start);
-        end_date = Util.ical_to_date_time (dt_end);
+
+        if (dt_end.is_null_time () == 0) {
+            end_date = Util.ical_to_date_time (dt_end);
+        } else if (dt_start.is_it_date () == 0) {
+            end_date = start_date;
+        } else if (comp.get_duration ().is_null_duration () == 0){
+            end_date = Util.ical_to_date_time (dt_start.add (comp.get_duration ()));
+        } else {
+            end_date = start_date.add_days (1);
+        }
 
         if (is_all_day (start_date, end_date)) {
             end_date = end_date.add_days (-1);
@@ -117,12 +125,8 @@ namespace Maya.Util {
     }
 
     public bool is_event_in_range (iCal.Component comp, Util.DateRange view_range) {
-        var start = ical_to_date_time (comp.get_dtstart ());
-        var end = ical_to_date_time (comp.get_dtend ());
-
-        if (is_all_day (start, end)) {
-            end = end.add_days (-1);
-        }
+        DateTime start, end;
+        get_local_datetimes_from_icalcomponent (comp, out start, out end);
 
         int c1 = start.compare (view_range.first_dt);
         int c2 = start.compare (view_range.last_dt);
@@ -159,14 +163,8 @@ namespace Maya.Util {
     public Gee.Collection<DateRange> event_date_ranges (iCal.Component comp, Util.DateRange view_range) {
         var dateranges = new Gee.LinkedList<DateRange> ();
 
-        var start = ical_to_date_time (comp.get_dtstart ());
-        var end = ical_to_date_time (comp.get_dtend ());
-        if (end == null) end = start;
-
-        // All days events are stored in UTC time and should only being shown at one day.
-        if (is_all_day (start, end)) {
-            end = end.add_days (-1);
-        }
+        DateTime start, end;
+        get_local_datetimes_from_icalcomponent (comp, out start, out end);
 
         start = strip_time (start);
         end = strip_time (end);
@@ -450,11 +448,8 @@ namespace Maya.Util {
     }
 
     public bool is_multiday_event (iCal.Component comp) {
-        var start = ical_to_date_time (comp.get_dtstart ());
-        var end = ical_to_date_time (comp.get_dtend ());
-
-        if (is_all_day (start, end))
-            end = end.add_days (-1);
+        DateTime start, end;
+        get_local_datetimes_from_icalcomponent (comp, out start, out end);
 
         if (start.get_year () != end.get_year () || start.get_day_of_year () != end.get_day_of_year ())
             return true;

--- a/src/EventEdition/InfoPanel.vala
+++ b/src/EventEdition/InfoPanel.vala
@@ -246,7 +246,7 @@ public class Maya.View.EventEdition.InfoPanel : Gtk.Grid {
 
             // Load the allday_switch
             if (allday) {
-                allday_switch.set_active(true);
+                allday_switch.set_active (true);
                 from_time_picker.sensitive = false;
                 to_time_picker.sensitive = false;
             }

--- a/src/EventEdition/InfoPanel.vala
+++ b/src/EventEdition/InfoPanel.vala
@@ -220,37 +220,28 @@ public class Maya.View.EventEdition.InfoPanel : Gtk.Grid {
 
             // Load the title
             string summary = comp.get_summary ();
-            if (summary != null)
+            if (summary != null) {
                 title_entry.text = summary;
-
-            // Load the dates
-            iCal.TimeType dt_start = comp.get_dtstart ();
-            iCal.TimeType dt_end = comp.get_dtend ();
+            }
 
             DateTime from_date, to_date;
             Util.get_local_datetimes_from_icalcomponent (comp, out from_date, out to_date);
 
-            if (dt_start.year != 0) {
-                from_date_picker.date = from_date;
-                from_time_picker.time = from_date;
-                parent_dialog.date_time = from_date;
-            }
+            from_date_picker.date = from_date;
+            from_time_picker.time = from_date;
+            parent_dialog.date_time = from_date;
 
             // Is this all day
             bool allday = Util.is_all_day(from_date, to_date);
 
-            if (dt_end.year != 0) {
-                to_date_picker.date = to_date;
-                to_time_picker.time = to_date;
-            }
+            to_date_picker.date = to_date;
+            to_time_picker.time = to_date;
 
             // Load the allday_switch
-            if (dt_end.year != 0) {
-                if (allday) {
-                    allday_switch.set_active(true);
-                    from_time_picker.sensitive = false;
-                    to_time_picker.sensitive = false;
-                }
+            if (allday) {
+                allday_switch.set_active(true);
+                from_time_picker.sensitive = false;
+                to_time_picker.sensitive = false;
             }
 
             unowned iCal.Property property = comp.get_first_property (iCal.PropertyKind.DESCRIPTION);

--- a/src/Grid/GridDay.vala
+++ b/src/Grid/GridDay.vala
@@ -106,9 +106,13 @@ public class Maya.View.GridDay : Gtk.EventBox {
         var end = icalcomp.get_dtend ();
         var gap = date.get_day_of_month () - start.day;
         start.day += gap;
-        end.day += gap;
+
+        if (end.is_null_time () == 0) {
+            end.day += gap;
+            icalcomp.set_dtend (end);
+        }
+
         icalcomp.set_dtstart (start);
-        icalcomp.set_dtend (end);
         calmodel.update_event (src, comp, E.CalObjModType.ALL);
     }
 


### PR DESCRIPTION
This moves all the iCal.TimeType conversion in utils to the get_local_datetimes_from_icalcomponent to reduce code repetition and modifies the handling of dtends to handle if there is no dtend specified to match the behaviour defined in the spec (https://tools.ietf.org/html/rfc5545#section-3.6.1)

Hopefully this fixes #180