### PR TITLE
Correctly import ics files

### DIFF
--- a/src/ImportDialog.vala
+++ b/src/ImportDialog.vala
@@ -74,11 +74,14 @@ public class Maya.View.ImportDialog : Gtk.Dialog {
         var source = calchooser_button.current_source;
         var calmodel = Model.CalendarModel.get_default ();
         foreach (var file in files) {
-            var ecal = new E.CalComponent ();
             var ical = E.Util.parse_ics_file (file.get_path ());
             if (ical.is_valid () == 1) {
-                ecal.set_icalcomponent ((owned) ical);
-                calmodel.add_event (source, ecal);
+                for (unowned iCal.Component comp = ical.get_first_component (iCal.ComponentKind.VEVENT);
+                     comp != null;
+                     comp = ical.get_next_component (iCal.ComponentKind.VEVENT)) {
+                    var ecal = new E.CalComponent.from_string  (comp.as_ical_string ());
+                    calmodel.add_event (source, ecal);
+                }
             }
         }
 

--- a/src/ImportDialog.vala
+++ b/src/ImportDialog.vala
@@ -79,7 +79,7 @@ public class Maya.View.ImportDialog : Gtk.Dialog {
                 for (unowned iCal.Component comp = ical.get_first_component (iCal.ComponentKind.VEVENT);
                      comp != null;
                      comp = ical.get_next_component (iCal.ComponentKind.VEVENT)) {
-                    var ecal = new E.CalComponent.from_string  (comp.as_ical_string ());
+                    var ecal = new E.CalComponent.from_string (comp.as_ical_string ());
                     calmodel.add_event (source, ecal);
                 }
             }


### PR DESCRIPTION
This fixes the import behaviour, so that it will import all VEVENTs correctly from an ics file (I had to use the libical iterators so it ended up with a pretty ugly for loop.) Previously it was taking the whole ics file as a single component for one event, which is naturally not the correct behaviour.

Fixes #56 
Fixes #52 