### PR TITLE
Add missing releases to appdata

### DIFF
--- a/data/org.pantheon.maya.appdata.xml.in.in
+++ b/data/org.pantheon.maya.appdata.xml.in.in
@@ -13,6 +13,9 @@
     </_p>
   </description>
   <releases>
+    <release version="0.4.0.2" timestamp="1473189266"/>
+    <release version="0.4.0.1" timestamp="1471195865"/>
+    <release version="0.4" timestamp="1470925887"/>
     <release version="0.3.1.1" timestamp="1432996164"/>
     <release version="0.3.1" timestamp="1428358074"/>
     <release version="0.3" timestamp="1386579562"/>


### PR DESCRIPTION
Adds the 0.4 series of releases to the appdata.

Release commits:
0.4.0.2: https://github.com/elementary/calendar/commit/ea2bf947352b9c5dd3311e233680596f9725fd6d
0.4.0.1: https://github.com/elementary/calendar/commit/9e6d7e0b763e61c65503cc115e56b66a30afa1fd
0.4: https://github.com/elementary/calendar/commit/1a2b78dcd80094afa9ee6b6267a12a08c8add956