### PR TITLE
Add remove occurrence button

### DIFF
--- a/src/Grid/EventButton.vala
+++ b/src/Grid/EventButton.vala
@@ -66,9 +66,9 @@ public class Maya.View.EventButton : Gtk.Revealer {
 
                 Gtk.MenuItem remove_item;
                 if (comp.has_recurrences ()) {
-                    remove_item = new Gtk.MenuItem.with_label (_("Remove series"));
-                    Gtk.MenuItem exception_item = new Gtk.MenuItem.with_label (_("Remove occurrence"));
-                    exception_item.activate.connect (() => { add_exception (); });
+                    remove_item = new Gtk.MenuItem.with_label (_("Remove Series"));
+                    Gtk.MenuItem exception_item = new Gtk.MenuItem.with_label (_("Remove Occurrence"));
+                    exception_item.activate.connect (add_exception);
                     exception_item.sensitive = sensitive;
                     menu.append (exception_item);
                 } else {
@@ -76,7 +76,7 @@ public class Maya.View.EventButton : Gtk.Revealer {
                 }
 
                 remove_item.sensitive = sensitive;
-                remove_item.activate.connect (() => { remove_event (); });
+                remove_item.activate.connect (remove_event);
                 menu.append (remove_item);
 
                 menu.popup (null, null, null, event.button, event.time);

--- a/src/Grid/EventButton.vala
+++ b/src/Grid/EventButton.vala
@@ -66,7 +66,7 @@ public class Maya.View.EventButton : Gtk.Revealer {
 
                 Gtk.MenuItem remove_item;
                 if (comp.has_recurrences ()) {
-                    remove_item = new Gtk.MenuItem.with_label (_("Remove Series"));
+                    remove_item = new Gtk.MenuItem.with_label (_("Remove Event"));
                     Gtk.MenuItem exception_item = new Gtk.MenuItem.with_label (_("Remove Occurrence"));
                     exception_item.activate.connect (add_exception);
                     exception_item.sensitive = sensitive;

--- a/src/Grid/Grid.vala
+++ b/src/Grid/Grid.vala
@@ -191,7 +191,7 @@ public class Grid : Gtk.Grid {
      */
     void add_buttons_for_range (Util.DateRange dt_range, E.CalComponent event) {
         foreach (var date in dt_range) {
-            EventButton button = new EventButton (event);
+            EventButton button = new EventButton (event, date);
             add_button_for_day (date, button);
             button.edition_request.connect (() => {
                 edition_request (event);
@@ -234,7 +234,7 @@ public class Grid : Gtk.Grid {
 
             if (contains) {
                 if (!grid_day.update_event (event)) {
-                    EventButton button = new EventButton (event);
+                    EventButton button = new EventButton (event, grid_day.date);
                     add_button_for_day (grid_day.date, button);
 
                     button.edition_request.connect (() => {


### PR DESCRIPTION
When an event has repetitions this makes it so right clicking on them in the grid includes remove series and remove occurrence buttons rather than the generic remove, this is to create a simpler way to add exception dates.
