### PR TITLE
Update version information

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -255,7 +255,7 @@ namespace Maya {
 
         if (Option.PRINT_VERSION) {
             stdout.printf("Maya %s\n", Build.VERSION);
-            stdout.printf("Copyright 2011-2015 Maya Developers.\n");
+            stdout.printf("Copyright 2011-2017 elementary LLC.\n");
             return 0;
         }
 


### PR DESCRIPTION
The year update shouldn't be controversial at all, but I did change "Maya Developers" to "elementary LLC", particularly if we are renaming to just Calendar and moving to RDNN names under "io.elementary" this makes sense to avoid confusion.