### PR TITLE
Fallback to char wrapping if word is too long to wrap

### DIFF
--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -480,6 +480,7 @@ public class Maya.View.AgendaView : Gtk.Grid {
             name_label = new Gtk.Label ("");
             name_label.hexpand = true;
             name_label.wrap = true;
+            name_label.wrap_mode = Pango.WrapMode.WORD_CHAR;
             name_label.xalign = 0;
 
             datatime_label = new Gtk.Label ("");


### PR DESCRIPTION
Before:
![screenshot from 2017-11-22 22 27 06](https://user-images.githubusercontent.com/18336287/33152688-cc01950e-cfd5-11e7-9160-ab1dbd1a687e.png)

After:
![screenshot from 2017-11-22 22 29 18](https://user-images.githubusercontent.com/18336287/33152691-d43196d4-cfd5-11e7-9d45-fe36511986e9.png)


Fixes #198 