### PR TITLE
Utils: Update location of datetime indicator setting

### DIFF
--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -731,7 +731,7 @@ namespace Maya.Util {
         return "#%02X%02X%02X".printf ((uint)(color.red*255), (uint)(color.green*255), (uint)(color.blue*255));
     }
 
-    public const string SHOW_WEEKS_SCHEMA = "org.pantheon.desktop.wingpanel.indicators.datetime";
+    public const string SHOW_WEEKS_SCHEMA = "io.elementary.desktop.wingpanel.datetime";
 
     public bool show_weeks () {
         if (GLib.SettingsSchemaSource.get_default ().lookup (SHOW_WEEKS_SCHEMA, false) != null) {


### PR DESCRIPTION
Because of https://github.com/elementary/wingpanel-indicator-datetime/pull/71