### PR TITLE
Eliminate Gtk warning about :focused

### DIFF
--- a/data/style/sidebar.css
+++ b/data/style/sidebar.css
@@ -27,6 +27,6 @@
 	border-radius: 0;
 }
 
-.sidebarevent:focused {
+.sidebarevent:focus {
 	background-color: shade(@bg_color, 0.9);
 }


### PR DESCRIPTION
Eliminate this warning:
(io.elementary.calendar:13709): Gtk-WARNING **: 21:32:17.677: Theme parsing error: sidebar.css:30:21: The :focused pseudo-class is deprecated. Use :focus instead.