### PR TITLE
Add padding to weeknumber labels

### DIFF
--- a/data/style/calendar.css
+++ b/data/style/calendar.css
@@ -55,3 +55,9 @@
 	.cell > #date {
 		font-size: 8px;
 	}
+
+/* Week Number Styles */
+.weeklabel {
+	padding: 3px;
+}
+

--- a/src/Grid/WeekLabels.vala
+++ b/src/Grid/WeekLabels.vala
@@ -113,11 +113,14 @@ public class WeekLabels : Gtk.Revealer {
 
         // Create new labels
         labels = new Gtk.Label[nr_of_weeks];
+        var style_provider = Util.Css.get_css_provider ();
         for (int c = 0; c < nr_of_weeks; c++) {
             labels[c] = new Gtk.Label ("");
             labels[c].valign = Gtk.Align.START;
             labels[c].width_chars = 2;
             labels[c].draw.connect (on_draw);
+            labels[c].get_style_context().add_provider (style_provider, 600);
+            labels[c].get_style_context().add_class ("weeklabel");
             day_grid.attach (labels[c], 0, c, 1, 1);
             labels[c].show ();
         }


### PR DESCRIPTION
This adds padding to the Week Number Labels so that it feels less cramped. Initially, I tried `6px` all around, but it felt a little too roomy. I ended up using `3px` as shown in the screenshot below.

![image](https://user-images.githubusercontent.com/2007067/46435521-1cbd9b80-c71c-11e8-9f46-2177127f3617.png)

Fixes #126 (a little pet peeve of mine)