### PR TITLE
Fix Location Panel Initialization

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,7 @@ clutter_dep = dependency('clutter-1.0')
 clutter_gtk_dep = dependency('clutter-gtk-1.0')
 folks_dep = dependency('folks')
 geocode_glib_dep = dependency('geocode-glib-1.0')
+gclue_dep = dependency('libgeoclue-2.0')
 
 m_dep = meson.get_compiler('c').find_library('m', required : false)
 libnotify_dep = dependency('libnotify', required: false)

--- a/src/EventEdition/LocationPanel.vala
+++ b/src/EventEdition/LocationPanel.vala
@@ -243,6 +243,8 @@ public class Maya.View.EventEdition.LocationPanel : Gtk.Grid {
 
         } catch (Error e) {
             warning ("Failed to connect to GeoClue2 service: %s", e.message);
+            // Fallback to timezone location
+            compute_location.begin (E.Util.get_system_timezone_location ());
             return;
         }
     }

--- a/src/EventEdition/LocationPanel.vala
+++ b/src/EventEdition/LocationPanel.vala
@@ -128,7 +128,8 @@ public class Maya.View.EventEdition.LocationPanel : Gtk.Grid {
             }
         }
 
-        view.zoom_level = 8;
+        view.zoom_level = 10;
+        view.goto_animation_duration = 500;
         view.center_on (point.latitude, point.longitude);
         marker_layer.add_marker (point);
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -51,7 +51,8 @@ calendar_deps = [
     clutter_dep,
     clutter_gtk_dep,
     folks_dep,
-    geocode_glib_dep
+    geocode_glib_dep,
+    gclue_dep
 ]
 
 executable(


### PR DESCRIPTION
When adding a new event, the location panel gets initialized with the location of the timezone. This is bad for people like me, who live in Dallas but have a timezone in Chicago. That means every time I add an event with a location, I have to wait for the map to scroll to Chicago, and then I have to type in a location and wait for the map to scroll to Dallas. There are a few things wrong with this:
- The map centers on a city I've never even been to, which is confusing
- The map takes a very long time to scroll to locations
- The zoom level is too far up to be useful

This PR:
- [x] Uses `libgeoclue-2.0` to find the approximate location of the user.
- [x] Sets the animation duration to 500ms, which is much snappier and still smooth
- [x] Sets the zoom level a little closer to see some street detail

I would like to work on another PR that uses some smarter logic to set the zoom level based on address detail (county, city, street, etc.). For now, this fixes #151.