### PR TITLE
Add libgeoclue as a dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,6 +17,7 @@ Build-Depends: debhelper (>= 10.5.1),
                libgtk-3-dev (>= 3.11.6),
                libical-dev,
                libnotify-dev,
+               libgeoclue-2-dev,
                meson,
                pkg-config,
                valac (>= 0.26.0)


### PR DESCRIPTION
This should [fingers crossed] make it so that the libgeoclue branch builds.