### PR TITLE
Remove cairo draws

### DIFF
--- a/data/style/calendar.css
+++ b/data/style/calendar.css
@@ -42,6 +42,10 @@
     border-left: solid 1px alpha(#000, 0.25);
 }
 
+.cell.firstcol {
+	border-left: none;
+}
+
 .other_month {
     background-color: shade(@cell_color, 0.97);
 }
@@ -64,6 +68,11 @@
 	}
 
 /* Week Number Styles */
+
+.weeks {
+	border-right: solid 1px alpha(#000, 0.25);
+}
+
 .weeklabel {
     border-top: solid 1px alpha(#000, 0.25);
 	padding: 3px;

--- a/data/style/calendar.css
+++ b/data/style/calendar.css
@@ -33,7 +33,7 @@
     border-left: solid 1px alpha(#000, 0.25);
 }
 
-.daylabel.firstcol {
+.daylabel:first-child {
     border-left: none;
 }
 

--- a/data/style/calendar.css
+++ b/data/style/calendar.css
@@ -28,6 +28,11 @@
 			from(@cell_color), to(mix(@bg_color, rgb(255, 255, 255), 0.8)));
 }
 
+.daylabel {
+    padding: 3px;
+    border-left: solid 1px alpha(#000, 0.25);
+}
+
 /* Cell Styles */
 
 .cell {

--- a/data/style/calendar.css
+++ b/data/style/calendar.css
@@ -33,6 +33,8 @@
 .cell {
 	background-color: @cell_color;
     border-radius: 0;
+    border-top: solid 1px alpha(#000, 0.25);
+    border-left: solid 1px alpha(#000, 0.25);
 }
 
 .other_month {

--- a/data/style/calendar.css
+++ b/data/style/calendar.css
@@ -33,6 +33,10 @@
     border-left: solid 1px alpha(#000, 0.25);
 }
 
+.daylabel.firstcol {
+    border-left: none;
+}
+
 /* Cell Styles */
 
 .cell {

--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -62,10 +62,6 @@ public class Maya.View.AgendaView : Gtk.Grid {
         selected_data_grid.add (day_label);
         selected_data_grid.add (separator);
 
-        var selected_data_style_provider = Util.Css.get_css_provider ();
-        selected_data_grid.get_style_context ().add_provider (selected_data_style_provider, 600);
-        selected_data_grid.get_style_context ().add_class ("cell");
-
         var placeholder_label = new Gtk.Label (_("Your upcoming events will be displayed here when you select a date with events."));
         placeholder_label.wrap = true;
         placeholder_label.wrap_mode = Pango.WrapMode.WORD;
@@ -153,10 +149,6 @@ public class Maya.View.AgendaView : Gtk.Grid {
         upcoming_events_grid.attach (upcoming_events_separatorTop, 0, 0, 1, 1);
         upcoming_events_grid.attach (upcoming_events_label, 0, 1, 1, 1);
         upcoming_events_grid.attach (upcoming_events_separatorBottom, 0, 2, 1, 1);
-
-        var upcoming_events_style_provider = Util.Css.get_css_provider ();
-        upcoming_events_grid.get_style_context ().add_provider (upcoming_events_style_provider, 600);
-        upcoming_events_grid.get_style_context ().add_class ("cell");
 
         upcoming_events_list = new Gtk.ListBox ();
         upcoming_events_list.selection_mode = Gtk.SelectionMode.SINGLE;

--- a/src/Grid/CalendarView.vala
+++ b/src/Grid/CalendarView.vala
@@ -37,6 +37,7 @@ public class Maya.View.CalendarView : Gtk.Grid {
     private Grid grid { get; private set; }
     private Gtk.Stack stack { get; private set; }
     private Gtk.Grid big_grid { get; private set; }
+    private Gtk.Label spacer { get; private set; }
     private GLib.Settings show_weeks;
 
     public CalendarView () {
@@ -83,6 +84,12 @@ public class Maya.View.CalendarView : Gtk.Grid {
     }
 
     public Gtk.Grid create_big_grid () {
+        var style_provider = Util.Css.get_css_provider ();
+
+        spacer = new Gtk.Label ("");
+        spacer.get_style_context().add_provider (style_provider, 600);
+        spacer.get_style_context().add_class ("weeks");
+
         weeks = new WeekLabels ();
         weeks.notify["child-revealed"].connect (() => {
             grid.draw_first_line_column (weeks.child_revealed);
@@ -102,6 +109,7 @@ public class Maya.View.CalendarView : Gtk.Grid {
 
         // Grid properties
         var new_big_grid = new Gtk.Grid ();
+        new_big_grid.attach (spacer, 0, 0, 1, 1);
         new_big_grid.attach (header, 1, 0, 1, 1);
         new_big_grid.attach (grid, 1, 1, 1, 1);
         new_big_grid.attach (weeks, 0, 1, 1, 1);
@@ -132,8 +140,11 @@ public class Maya.View.CalendarView : Gtk.Grid {
         var model = Model.CalendarModel.get_default ();
         weeks.update (model.data_range.first_dt, model.num_weeks);
         if (Util.show_weeks ()) {
+            spacer.show ();
             grid.draw_first_line_column (true);
             header.draw_left_border = true;
+        } else {
+            spacer.hide ();
         }
     }
 

--- a/src/Grid/CalendarView.vala
+++ b/src/Grid/CalendarView.vala
@@ -87,15 +87,11 @@ public class Maya.View.CalendarView : Gtk.Grid {
         var style_provider = Util.Css.get_css_provider ();
 
         spacer = new Gtk.Label ("");
+        spacer.no_show_all = true;
         spacer.get_style_context().add_provider (style_provider, 600);
         spacer.get_style_context().add_class ("weeks");
 
         weeks = new WeekLabels ();
-        weeks.notify["child-revealed"].connect (() => {
-            grid.draw_first_line_column (weeks.child_revealed);
-            header.draw_left_border = weeks.child_revealed;
-            header.queue_draw ();
-        });
 
         header = new Header ();
         grid = new Grid ();
@@ -115,6 +111,13 @@ public class Maya.View.CalendarView : Gtk.Grid {
         new_big_grid.attach (weeks, 0, 1, 1, 1);
         new_big_grid.show_all ();
         new_big_grid.expand = true;
+
+        if (!Util.show_weeks ())  {
+            spacer.hide ();
+        } else {
+            spacer.show ();
+        }
+
         return new_big_grid;
     }
 
@@ -141,8 +144,6 @@ public class Maya.View.CalendarView : Gtk.Grid {
         weeks.update (model.data_range.first_dt, model.num_weeks);
         if (Util.show_weeks ()) {
             spacer.show ();
-            grid.draw_first_line_column (true);
-            header.draw_left_border = true;
         } else {
             spacer.hide ();
         }

--- a/src/Grid/Grid.vala
+++ b/src/Grid/Grid.vala
@@ -182,18 +182,6 @@ public class Grid : Gtk.Grid {
     }
 
     /**
-     * Notify when the week number revealer is revealed
-     */
-    public void draw_first_line_column (bool draw) {
-        var lines = get_children ().length () / 7;
-        for (int i = 0; i < lines; i++) {
-            var child = get_child_at (0, i);
-            ((GridDay)child).draw_left_border = draw;
-            child.queue_draw ();
-        }
-    }
-
-    /**
      * Adds an eventbutton to the grid for the given event at each day of the given range.
      */
     void add_buttons_for_range (Util.DateRange dt_range, E.CalComponent event) {

--- a/src/Grid/Grid.vala
+++ b/src/Grid/Grid.vala
@@ -106,6 +106,8 @@ public class Grid : Gtk.Grid {
         int i=0;
         int col = 0, row = 0;
 
+        var style_provider = Util.Css.get_css_provider ();
+
         for (i=0; i<new_dates.size; i++) {
             var new_date = new_dates [i];
             GridDay day;
@@ -124,6 +126,11 @@ public class Grid : Gtk.Grid {
                     on_day_focus_in (day);
                     return false;
                 });
+
+                if (col == 0) {
+                    day.get_style_context().add_provider (style_provider, 600);
+                    day.get_style_context().add_class ("firstcol");
+                }
 
                 attach (day, col, row, 1, 1);
                 day.show_all ();

--- a/src/Grid/GridDay.vala
+++ b/src/Grid/GridDay.vala
@@ -116,33 +116,6 @@ public class Maya.View.GridDay : Gtk.EventBox {
         calmodel.update_event (src, comp, E.CalObjModType.ALL);
     }
 
-    public override bool draw (Cairo.Context cr) {
-        base.draw (cr);
-        Gtk.Allocation size;
-        get_allocation (out size);
-
-        // Draw left and top black strokes
-        if (draw_left_border == false) {
-            cr.move_to (0.5, 0.5);
-        } else {
-            cr.move_to (0.5, size.height); // start in bottom left. 0.5 accounts for cairo's default stroke offset of 1/2 pixels
-            cr.line_to (0.5, 0.5); // move to upper left corner
-        }
-
-        cr.line_to (size.width + 0.5, 0.5); // move to upper right corner
-
-        cr.set_source_rgba (0.0, 0.0, 0.0, 0.25);
-        cr.set_line_width (1.0);
-        cr.set_antialias (Cairo.Antialias.NONE);
-        cr.stroke ();
-
-        // Draw inner highlight stroke
-        cr.rectangle (1, 1, size.width - 1, size.height - 1);
-        cr.set_source_rgba (1.0, 1.0, 1.0, 0.2);
-        cr.stroke ();
-        return false;
-    }
-
     public void add_event_button (EventButton button) {
         unowned iCal.Component calcomp = button.comp.get_icalcomponent ();
         string uid = calcomp.get_uid ();

--- a/src/Grid/Header.vala
+++ b/src/Grid/Header.vala
@@ -53,6 +53,9 @@ public class Header : Gtk.EventBox {
             labels[c].hexpand = true;
             labels[c].get_style_context().add_provider (style_provider, 600);
             labels[c].get_style_context().add_class ("daylabel");
+            if (c == 0) {
+                labels[c].get_style_context().add_class ("firstcol");
+            }
             var label_grid = new Gtk.Grid ();
             label_grid.add (labels[c]);
             header_grid.attach (label_grid, c, 0, 1, 1);

--- a/src/Grid/Header.vala
+++ b/src/Grid/Header.vala
@@ -28,7 +28,6 @@ public class Header : Gtk.EventBox {
     private Gtk.Grid header_grid;
     private Gtk.Label[] labels;
 
-    public bool draw_left_border = true;
     public Header () {
         events |= Gdk.EventMask.BUTTON_PRESS_MASK;
 

--- a/src/Grid/Header.vala
+++ b/src/Grid/Header.vala
@@ -52,12 +52,7 @@ public class Header : Gtk.EventBox {
             labels[c].hexpand = true;
             labels[c].get_style_context().add_provider (style_provider, 600);
             labels[c].get_style_context().add_class ("daylabel");
-            if (c == 0) {
-                labels[c].get_style_context().add_class ("firstcol");
-            }
-            var label_grid = new Gtk.Grid ();
-            label_grid.add (labels[c]);
-            header_grid.attach (label_grid, c, 0, 1, 1);
+            header_grid.attach (labels[c], c, 0, 1, 1);
         }
 
         add (header_grid);

--- a/src/Grid/Header.vala
+++ b/src/Grid/Header.vala
@@ -51,10 +51,9 @@ public class Header : Gtk.EventBox {
         for (int c = 0; c < 7; c++) {
             labels[c] = new Gtk.Label ("");
             labels[c].hexpand = true;
-            labels[c].margin_top = 4;
-            labels[c].margin_bottom = 2;
+            labels[c].get_style_context().add_provider (style_provider, 600);
+            labels[c].get_style_context().add_class ("daylabel");
             var label_grid = new Gtk.Grid ();
-            label_grid.draw.connect (on_draw);
             label_grid.add (labels[c]);
             header_grid.attach (label_grid, c, 0, 1, 1);
         }
@@ -90,26 +89,6 @@ public class Header : Gtk.EventBox {
             label.label = date.format ("%a");
             date = date.add_days (1);
         }
-    }
-
-    private bool on_draw (Gtk.Widget widget, Cairo.Context cr) {
-        Gtk.Allocation size;
-        widget.get_allocation (out size);
-
-        // Draw left border
-        if (widget == header_grid.get_child_at (0, 0) && draw_left_border == false) {
-            return false;
-        }
-
-        cr.move_to (0.5, size.height); // start in bottom left. 0.5 accounts for cairo's default stroke offset of 1/2 pixels
-        cr.line_to (0.5, 0.5); // move to upper left corner
-
-        cr.set_source_rgba (0.0, 0.0, 0.0, 0.25);
-        cr.set_line_width (1.0);
-        cr.set_antialias (Cairo.Antialias.NONE);
-        cr.stroke ();
-
-        return false;
     }
 }
 


### PR DESCRIPTION
This branch primarily removes Cairo draw functions that were used to draw the borders of the grid. Instead, there is CSS to take care of the drawing.

The only funkiness is in the `CalendarView.vala` where the top left corner had to be filled with a blank label widget in order to draw a border next to the Sunday label. If the Sunday label draws the border, it is not in line with the week number border. Additionally, the blank widget needs to be shown and hidden when the week numbers are revealed/hidden, so it is slightly more complicated than I wish it could be.

What's important here is that it works and it uses less code and more CSS to draw the borders. If anyone has questions, feel free to hit me up.