### PR TITLE
Symbols: Remove deleted window state symbols

### DIFF
--- a/debian/libmaya-calendar0.symbols
+++ b/debian/libmaya-calendar0.symbols
@@ -67,15 +67,9 @@ libelementary-calendar.so.0 libmaya-calendar0 #MINVER#
  maya_settings_saved_state_get_selected_day@Base 0.3
  maya_settings_saved_state_get_show_weeks@Base 0.3
  maya_settings_saved_state_get_type@Base 0.3
- maya_settings_saved_state_get_window_height@Base 0.3
- maya_settings_saved_state_get_window_state@Base 0.3
- maya_settings_saved_state_get_window_width@Base 0.3
  maya_settings_saved_state_set_month_page@Base 0.3
  maya_settings_saved_state_set_selected_day@Base 0.3
  maya_settings_saved_state_set_show_weeks@Base 0.3
- maya_settings_saved_state_set_window_height@Base 0.3
- maya_settings_saved_state_set_window_state@Base 0.3
- maya_settings_saved_state_set_window_width@Base 0.3
  maya_settings_weekday_get_type@Base 0.3
  maya_settings_window_state_get_type@Base 0.3
  maya_util_calcomponent_equal_func@Base 0.3

--- a/debian/libmaya-calendar0.symbols
+++ b/debian/libmaya-calendar0.symbols
@@ -61,7 +61,6 @@ libelementary-calendar.so.0 libmaya-calendar0 #MINVER#
  maya_settings_maya_settings_get_type@Base 0.3
  maya_settings_maya_settings_set_plugins_disabled@Base 0.3
  maya_settings_saved_state_get_default@Base 0.3
- maya_settings_saved_state_get_hpaned_position@Base 0.3
  maya_settings_saved_state_get_month_page@Base 0.3
  maya_settings_saved_state_get_page@Base 0.3
  maya_settings_saved_state_get_selected@Base 0.3
@@ -71,7 +70,6 @@ libelementary-calendar.so.0 libmaya-calendar0 #MINVER#
  maya_settings_saved_state_get_window_height@Base 0.3
  maya_settings_saved_state_get_window_state@Base 0.3
  maya_settings_saved_state_get_window_width@Base 0.3
- maya_settings_saved_state_set_hpaned_position@Base 0.3
  maya_settings_saved_state_set_month_page@Base 0.3
  maya_settings_saved_state_set_selected_day@Base 0.3
  maya_settings_saved_state_set_show_weeks@Base 0.3


### PR DESCRIPTION
This is all internal API and it's changing due to using GLib.Settings instead of Granite.Settings

Makes https://github.com/elementary/calendar/pull/289 pass