### PR TITLE
SourceDialog.vala: Choose colors from the palette

### DIFF
--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -623,10 +623,6 @@ namespace Maya.Util {
         }
     }
 
-    public string get_hexa_color (Gdk.RGBA color) {
-        return "#%02X%02X%02X".printf ((uint)(color.red*255), (uint)(color.green*255), (uint)(color.blue*255));
-    }
-
     public const string SHOW_WEEKS_SCHEMA = "io.elementary.desktop.wingpanel.datetime";
 
     public bool show_weeks () {

--- a/data/maya.gresource.xml
+++ b/data/maya.gresource.xml
@@ -4,6 +4,7 @@
     <file alias="calendar-go-today.svg" compressed="true" preprocess="xml-stripblanks">calendar-go-today.svg</file>
     <file alias="location-marker.svg" compressed="true" preprocess="xml-stripblanks">LocationMarker.svg</file>
     <file alias="calendar.css" compressed="true">style/calendar.css</file>
+    <file alias="ColorButton.css" compressed="true">style/ColorButton.css</file>
     <file alias="default.css" compressed="true">style/default.css</file>
     <file alias="sidebar.css" compressed="true">style/sidebar.css</file>
   </gresource>

--- a/data/style/ColorButton.css
+++ b/data/style/ColorButton.css
@@ -1,0 +1,42 @@
+.color-button radio,
+.color-button radio:checked {
+    border-color: alpha (#000, 0.3);
+    box-shadow:
+        inset 0 1px 0 0 alpha (@inset_dark_color, 0.7),
+        inset 0 0 0 1px alpha (@inset_dark_color, 0.3),
+        0 1px 0 0 alpha (@bg_highlight_color, 0.3);
+    padding: 3px;
+    -gtk-icon-shadow: none;
+}
+
+.color-button.red radio {
+    background: @STRAWBERRY_300;
+}
+
+.color-button.orange radio {
+    background: @ORANGE_300;
+}
+
+.color-button.yellow radio {
+    background: @BANANA_500;
+}
+
+.color-button.green radio {
+    background: @LIME_500;
+}
+
+.color-button.blue radio {
+    background: @BLUEBERRY_500;
+}
+
+.color-button.purple radio {
+    background: @GRAPE_500;
+}
+
+.color-button.brown radio {
+    background: @COCOA_300;
+}
+
+.color-button.slate radio {
+    background: @SLATE_300;
+}

--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -23,8 +23,8 @@ public class Maya.View.SourceDialog : Gtk.Grid {
     public EventType event_type { get; private set; default=EventType.EDIT;}
 
     private Gtk.Entry name_entry;
-    private Gtk.ColorButton color_button;
     private bool set_as_default = false;
+    private string hex_color;
     private Backend current_backend;
     private Gee.Collection<PlacementWidget> backend_widgets;
     private Gtk.Grid main_grid;
@@ -33,6 +33,15 @@ public class Maya.View.SourceDialog : Gtk.Grid {
     private Gtk.ComboBox type_combobox;
     private Gtk.ListStore list_store;
     private E.Source source = null;
+
+    private Gtk.RadioButton color_button_red;
+    private Gtk.RadioButton color_button_orange;
+    private Gtk.RadioButton color_button_yellow;
+    private Gtk.RadioButton color_button_green;
+    private Gtk.RadioButton color_button_blue;
+    private Gtk.RadioButton color_button_purple;
+    private Gtk.RadioButton color_button_brown;
+    private Gtk.RadioButton color_button_slate;
 
     public signal void go_back ();
 
@@ -95,17 +104,67 @@ public class Maya.View.SourceDialog : Gtk.Grid {
 
         type_combobox.set_active (0);
 
-        var rgba = Gdk.RGBA ();
-        rgba.red = 0.13;
-        rgba.green = 0.42;
-        rgba.blue = 0.70;
-        rgba.alpha = 1;
+        var css_provider = new Gtk.CssProvider ();
+        css_provider.load_from_resource ("/io/elementary/calendar/ColorButton.css");
 
         var color_label = new Gtk.Label (_("Color:"));
         color_label.xalign = 1;
 
-        color_button = new Gtk.ColorButton.with_rgba (rgba);
-        color_button.use_alpha = false;
+        color_button_red = new Gtk.RadioButton (null);
+
+        var color_button_red_context = color_button_red.get_style_context ();
+        color_button_red_context.add_class ("color-button");
+        color_button_red_context.add_class ("red");
+        color_button_red_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        color_button_orange = new Gtk.RadioButton.from_widget (color_button_red);
+
+        var color_button_orange_context = color_button_orange.get_style_context ();
+        color_button_orange_context.add_class ("color-button");
+        color_button_orange_context.add_class ("orange");
+        color_button_orange_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        color_button_yellow = new Gtk.RadioButton.from_widget (color_button_red);
+
+        var color_button_yellow_context = color_button_yellow.get_style_context ();
+        color_button_yellow_context.add_class ("color-button");
+        color_button_yellow_context.add_class ("yellow");
+        color_button_yellow_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        color_button_green = new Gtk.RadioButton.from_widget (color_button_red);
+
+        var color_button_green_context = color_button_green.get_style_context ();
+        color_button_green_context.add_class ("color-button");
+        color_button_green_context.add_class ("green");
+        color_button_green_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        color_button_blue = new Gtk.RadioButton.from_widget (color_button_red);
+
+        var color_button_blue_context = color_button_blue.get_style_context ();
+        color_button_blue_context.add_class ("color-button");
+        color_button_blue_context.add_class ("blue");
+        color_button_blue_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        color_button_purple = new Gtk.RadioButton.from_widget (color_button_red);
+
+        var color_button_purple_context = color_button_purple.get_style_context ();
+        color_button_purple_context.add_class ("color-button");
+        color_button_purple_context.add_class ("purple");
+        color_button_purple_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        color_button_brown = new Gtk.RadioButton.from_widget (color_button_red);
+
+        var color_button_brown_context = color_button_brown.get_style_context ();
+        color_button_brown_context.add_class ("color-button");
+        color_button_brown_context.add_class ("brown");
+        color_button_brown_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        color_button_slate = new Gtk.RadioButton.from_widget (color_button_red);
+
+        var color_button_slate_context = color_button_slate.get_style_context ();
+        color_button_slate_context.add_class ("color-button");
+        color_button_slate_context.add_class ("slate");
+        color_button_slate_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         var check_button = new Gtk.CheckButton.with_label (_("Mark as default calendar"));
 
@@ -113,16 +172,55 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             set_as_default = !set_as_default;
         });
 
+        color_button_red.toggled.connect (() => {
+            hex_color = "#da3d41";
+        });
+
+        color_button_orange.toggled.connect (() => {
+            hex_color = "#f37329";
+        });
+
+        color_button_yellow.toggled.connect (() => {
+            hex_color = "#e6a92a";
+        });
+
+        color_button_green.toggled.connect (() => {
+            hex_color = "#81c837";
+        });
+
+        color_button_blue.toggled.connect (() => {
+            hex_color = "#3689e6";
+        });
+
+        color_button_purple.toggled.connect (() => {
+            hex_color = "#a56de2";
+        });
+
+        color_button_brown.toggled.connect (() => {
+            hex_color = "#8a715e";
+        });
+
+        color_button_slate.toggled.connect (() => {
+            hex_color = "#667885";
+        });
+
         main_grid = new Gtk.Grid ();
         main_grid.row_spacing = 6;
         main_grid.column_spacing = 12;
-        main_grid.attach (type_label,    0, 0, 1, 1);
-        main_grid.attach (type_combobox, 1, 0, 1, 1);
-        main_grid.attach (name_label,    0, 1, 1, 1);
-        main_grid.attach (name_entry,    1, 1, 1, 1);
-        main_grid.attach (color_label,   0, 2, 1, 1);
-        main_grid.attach (color_button,  1, 2, 1, 1);
-        main_grid.attach (check_button,  1, 3, 1, 1);
+        main_grid.attach (type_label, 0, 0);
+        main_grid.attach (type_combobox, 1, 0, 8, 1);
+        main_grid.attach (name_label, 0, 1);
+        main_grid.attach (name_entry, 1, 1, 8, 1);
+        main_grid.attach (color_label, 0, 2);
+        main_grid.attach (color_button_red, 1, 2);
+        main_grid.attach (color_button_orange, 2, 2);
+        main_grid.attach (color_button_yellow, 3, 2);
+        main_grid.attach (color_button_green, 4, 2);
+        main_grid.attach (color_button_blue, 5, 2);
+        main_grid.attach (color_button_purple, 6, 2);
+        main_grid.attach (color_button_brown, 7, 2);
+        main_grid.attach (color_button_slate, 8, 2);
+        main_grid.attach (check_button, 1, 3, 8, 1);
 
         margin = 12;
         margin_bottom = 8;
@@ -140,12 +238,6 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             name_entry.text = "";
             type_combobox.sensitive = true;
             create_button.set_label (_("Create Calendar"));
-            var rgba = Gdk.RGBA ();
-            rgba.red = 0.13;
-            rgba.green = 0.42;
-            rgba.blue = 0.70;
-            rgba.alpha = 1;
-            color_button.set_rgba (rgba);
         } else {
             event_type = EventType.EDIT;
             create_button.set_label (_("Save"));
@@ -154,9 +246,34 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             type_combobox.set_active (0);
             list_store.foreach (tree_foreach);
             var cal = (E.SourceCalendar)source.get_extension (E.SOURCE_EXTENSION_CALENDAR);
-            var rgba = Gdk.RGBA ();
-            rgba.parse (cal.dup_color ());
-            color_button.set_rgba (rgba);
+
+            switch (cal.dup_color ()) {
+                case "#da3d41":
+                    color_button_red.active = true;
+                    break;
+                case "#f37329":
+                    color_button_orange.active = true;
+                    break;
+                case "#e6a92a":
+                    color_button_yellow.active = true;
+                    break;
+                case "#81c837":
+                    color_button_green.active = true;
+                    break;
+                case "#3689e6":
+                    color_button_blue.active = true;
+                    break;
+                case "#a56de2":
+                    color_button_purple.active = true;
+                    break;
+                case "#8a715e":
+                    color_button_brown.active = true;
+                    break;
+                case "#667885":
+                    color_button_slate.active = true;
+                    break;
+            }
+
         }
     }
 
@@ -220,10 +337,10 @@ public class Maya.View.SourceDialog : Gtk.Grid {
 
     public void save () {
         if (event_type == EventType.ADD) {
-            current_backend.add_new_calendar (name_entry.text, Util.get_hexa_color (color_button.rgba), set_as_default, backend_widgets);
+            current_backend.add_new_calendar (name_entry.text, hex_color, set_as_default, backend_widgets);
             go_back ();
         } else {
-            current_backend.modify_calendar (name_entry.text, Util.get_hexa_color (color_button.rgba), set_as_default, backend_widgets, source);
+            current_backend.modify_calendar (name_entry.text, hex_color, set_as_default, backend_widgets, source);
             go_back ();
         }
     }

--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -42,6 +42,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
     private Gtk.RadioButton color_button_purple;
     private Gtk.RadioButton color_button_brown;
     private Gtk.RadioButton color_button_slate;
+    private Gtk.RadioButton color_button_none;
 
     public signal void go_back ();
 
@@ -166,6 +167,8 @@ public class Maya.View.SourceDialog : Gtk.Grid {
         color_button_slate_context.add_class ("slate");
         color_button_slate_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
+        color_button_none = new Gtk.RadioButton.from_widget (color_button_red);
+
         var check_button = new Gtk.CheckButton.with_label (_("Mark as default calendar"));
 
         check_button.toggled.connect (() => {
@@ -271,6 +274,10 @@ public class Maya.View.SourceDialog : Gtk.Grid {
                     break;
                 case "#667885":
                     color_button_slate.active = true;
+                    break;
+                default:
+                    color_button_none.active = true;
+                    hex_color = cal.dup_color ();
                     break;
             }
 


### PR DESCRIPTION
Adds a quick radio button color selector instead of using a Gtk.ColorButton

![screenshot from 2018-11-13 15 36 31 2x](https://user-images.githubusercontent.com/7277719/48450150-0ca4cd00-e75a-11e8-8c6d-7b0889489e1e.png)
