### PR TITLE
calendar.css: Fix RTL borders, high contrast

### DIFF
--- a/data/style/calendar.css
+++ b/data/style/calendar.css
@@ -36,7 +36,7 @@
 
 
 .cell {
-    background-color: @bg_color;
+    background-color: @base_color;
     border-radius: 0;
     border-top: solid 1px alpha(#000, 0.25);
     border-left: solid 1px alpha(#000, 0.25);
@@ -46,7 +46,7 @@
     border-left: none;
 }
 
-.other_month {
+.cell.dim-label {
     background-color: shade(@bg_color, 0.96);
 }
 
@@ -74,4 +74,20 @@
 .weeklabel {
     border-top: solid 1px alpha(#000, 0.25);
     padding: 3px;
+}
+
+.cell:dir(rtl),
+.daylabel:dir(rtl) {
+    border-right: solid 1px alpha(#000, 0.25);
+    border-left: none;
+}
+
+.cell.firstcol:dir(rtl),
+.daylabel:first-child:dir(rtl),
+.weeks:dir(rtl) {
+    border-right: none;
+}
+
+.weeks:dir(rtl) {
+    border-left: solid 1px alpha(#000, 0.25);
 }

--- a/src/Grid/GridDay.vala
+++ b/src/Grid/GridDay.vala
@@ -40,10 +40,8 @@ public class Maya.View.GridDay : Gtk.EventBox {
     public bool in_current_month {
         set {
             if (value) {
-                get_style_context ().remove_class ("other_month");
                 get_style_context ().remove_class (Gtk.STYLE_CLASS_DIM_LABEL);
             } else {
-                get_style_context ().add_class ("other_month");
                 get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
             }
         }


### PR DESCRIPTION
Fixes #295 

Makes the contrast between regular days and other month days higher

![screenshot from 2018-12-10 12 16 21 2x](https://user-images.githubusercontent.com/7277719/49759066-7c34ac00-fc75-11e8-95c2-b8a60576bdef.png)
