### PR TITLE
top-align agenda event icons

### DIFF
--- a/src/Widgets/AgendaEventRow.vala
+++ b/src/Widgets/AgendaEventRow.vala
@@ -5,12 +5,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
@@ -52,6 +52,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
 
         event_image = new Gtk.Image.from_icon_name ("office-calendar-symbolic", Gtk.IconSize.MENU);
         event_image.margin_start = 6;
+        event_image.valign = Gtk.Align.START;
         Util.style_calendar_color (event_image, cal.dup_color ());
 
         cal.notify["color"].connect (() => {


### PR DESCRIPTION
Proposing for multi-line event titles. I think the top-aligned looks better, and more in line with the text baseline.

![screenshot from 2018-12-11 13 57 59](https://user-images.githubusercontent.com/611168/49829896-eff5b800-fd4c-11e8-9994-6382c3cf36cd.png)
