### PR TITLE
AgendaView: Remove Upcoming Events label

### DIFF
--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -135,21 +135,6 @@ public class Maya.View.AgendaView : Gtk.Grid {
         selected_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
         selected_scrolled.add (selected_date_events_list);
 
-        var upcoming_events_label = new Gtk.Label (_("Upcoming Events"));
-
-        var upcoming_events_separatorTop = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
-        upcoming_events_separatorTop.hexpand = true;
-
-        var upcoming_events_separatorBottom = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
-        upcoming_events_separatorBottom.hexpand = true;
-
-        var upcoming_events_grid = new Gtk.Grid ();
-        upcoming_events_grid.row_spacing = 6;
-        upcoming_events_grid.orientation = Gtk.Orientation.VERTICAL;
-        upcoming_events_grid.attach (upcoming_events_separatorTop, 0, 0, 1, 1);
-        upcoming_events_grid.attach (upcoming_events_label, 0, 1, 1, 1);
-        upcoming_events_grid.attach (upcoming_events_separatorBottom, 0, 2, 1, 1);
-
         upcoming_events_list = new Gtk.ListBox ();
         upcoming_events_list.selection_mode = Gtk.SelectionMode.SINGLE;
         upcoming_events_list.set_header_func (upcoming_header_update_func);
@@ -198,7 +183,7 @@ public class Maya.View.AgendaView : Gtk.Grid {
 
         attach (selected_data_grid, 0, 0, 1, 1);
         attach (selected_scrolled, 0, 1, 1, 1);
-        attach (upcoming_events_grid, 0, 2, 1, 1);
+        attach (new Gtk.Separator (Gtk.Orientation.HORIZONTAL), 0, 2);
         attach (upcoming_scrolled, 0, 3, 1, 2);
 
         row_table = new HashTable<string, AgendaEventRow> (str_hash, str_equal);


### PR DESCRIPTION
Since we already have headers on these sections, I don't think this is any less clear and it gives us more room for events.

## BEFORE
![screenshot from 2018-12-11 13 03 24 2x](https://user-images.githubusercontent.com/7277719/49830146-2a5b5700-fd45-11e8-975a-3456adc2f491.png)

## AFTER
![screenshot from 2018-12-11 13 03 10 2x](https://user-images.githubusercontent.com/7277719/49830145-2a5b5700-fd45-11e8-86e1-df542ddc9c38.png)