### PR TITLE
CalendarButton: subclass MenuButton, cleanup

### DIFF
--- a/src/Widgets/CalendarButton.vala
+++ b/src/Widgets/CalendarButton.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 elementary, Inc. (https://elementary.io)
+ * Copyright 2014-2018 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/Widgets/CalendarButton.vala
+++ b/src/Widgets/CalendarButton.vala
@@ -24,7 +24,6 @@ public class Maya.View.Widgets.CalendarButton : Gtk.MenuButton {
         get {
             return _current_source;
         }
-
         set {
             _current_source = value;
             calendar_grid.source = value;
@@ -32,7 +31,6 @@ public class Maya.View.Widgets.CalendarButton : Gtk.MenuButton {
         }
     }
 
-    private Gtk.ListBox list_box;
     private CalendarGrid calendar_grid;
 
     construct {
@@ -60,7 +58,7 @@ public class Maya.View.Widgets.CalendarButton : Gtk.MenuButton {
 
         current_source = registry.default_calendar;
 
-        list_box = new Gtk.ListBox ();
+        var list_box = new Gtk.ListBox ();
         list_box.activate_on_single_click = true;
 
         var scrolled = new Gtk.ScrolledWindow (null, null);

--- a/src/Widgets/CalendarButton.vala
+++ b/src/Widgets/CalendarButton.vala
@@ -74,10 +74,6 @@ public class Maya.View.Widgets.CalendarButton : Gtk.MenuButton {
         popover.width_request = 310;
         popover.add (scrolled);
 
-        list_box.add.connect (() => {
-            list_box.show_all ();
-        });
-
         list_box.set_header_func (header_update_func);
 
         list_box.set_sort_func ((row1, row2) => {
@@ -103,6 +99,7 @@ public class Maya.View.Widgets.CalendarButton : Gtk.MenuButton {
 
             var row = new Gtk.ListBoxRow ();
             row.add (calgrid);
+            row.show_all ();
 
             list_box.add (row);
 


### PR DESCRIPTION
* Bump copyright header
* Subclass Gtk.MenuButton instead of ToggleButton
* Use built-in popover and get rid of code about showing and hiding it
* Use new features of Gtk for scrollbox max content height
* Make a single-use function into a lambda
* Reduce scope of `list_box`