### PR TITLE
AgendaView: Use one scrolledwindow for events list

### DIFF
--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -19,7 +19,7 @@
  *              Corentin Noël <corentin@elementaryos.org>
  */
 
-public class Maya.View.AgendaView : Gtk.Grid {
+public class Maya.View.AgendaView : Gtk.ScrolledWindow {
     public signal void event_removed (E.CalComponent event);
     public signal void event_modified (E.CalComponent event);
 
@@ -58,6 +58,7 @@ public class Maya.View.AgendaView : Gtk.Grid {
         placeholder_label.show_all ();
 
         selected_date_events_list = new Gtk.ListBox ();
+        selected_date_events_list.height_request = 128;
         selected_date_events_list.selection_mode = Gtk.SelectionMode.SINGLE;
         selected_date_events_list.set_header_func (header_update_func);
         selected_date_events_list.set_placeholder (placeholder_label);
@@ -116,12 +117,8 @@ public class Maya.View.AgendaView : Gtk.Grid {
             return false;
         });
 
-        var selected_scrolled = new Gtk.ScrolledWindow (null, null);
-        selected_scrolled.expand = true;
-        selected_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
-        selected_scrolled.add (selected_date_events_list);
-
         upcoming_events_list = new Gtk.ListBox ();
+        upcoming_events_list.margin_top = 24;
         upcoming_events_list.selection_mode = Gtk.SelectionMode.SINGLE;
         upcoming_events_list.set_header_func (upcoming_header_update_func);
         upcoming_events_list.set_sort_func ((child1, child2) => {
@@ -162,17 +159,15 @@ public class Maya.View.AgendaView : Gtk.Grid {
             return Util.is_event_in_range (comp, range);
         });
 
-        var upcoming_scrolled = new Gtk.ScrolledWindow (null, null);
-        upcoming_scrolled.expand = true;
-        upcoming_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
-        upcoming_scrolled.add (upcoming_events_list);
+        var grid = new Gtk.Grid ();
+        grid.orientation = Gtk.Orientation.VERTICAL;
+        grid.get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
+        grid.add (selected_data_grid);
+        grid.add (selected_date_events_list);
+        grid.add (upcoming_events_list);
 
-        orientation = Gtk.Orientation.VERTICAL;
-        get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
-        add (selected_data_grid);
-        add (selected_scrolled);
-        add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
-        add (upcoming_scrolled);
+        hscrollbar_policy = Gtk.PolicyType.NEVER;
+        add (grid);
 
         row_table = new HashTable<string, AgendaEventRow> (str_hash, str_equal);
         row_table2 = new HashTable<string, AgendaEventRow> (str_hash, str_equal);


### PR DESCRIPTION
One big happy events list. Makes it a lot easier to see upcoming events

![screenshot from 2018-12-12 11 04 56 2x](https://user-images.githubusercontent.com/7277719/49892460-dceef080-fdfd-11e8-9853-7baeb4a54661.png)
