### PR TITLE
Calendar.css: match wingpanel's date selection CSS

### DIFF
--- a/data/style/calendar.css
+++ b/data/style/calendar.css
@@ -50,17 +50,26 @@
     background-color: @bg_color;
 }
 
-.cell:selected {
+#date {
+    border-radius: 50%;
+    min-height: 24px;
+    min-width: 24px;
+}
+
+.cell:selected #date {
     background-color: shade(@bg_color, 0.86);
     color: @fg_color;
 }
 
-#today {
-    background-color: mix(@bg_color, @selected_bg_color, 0.25);
+#today #date {
+    background-color: alpha (@colorAccent, 0.15);
+    color: @colorAccent;
+    font-weight: 700;
 }
 
-#today:selected {
-    background-color: mix(@bg_color, @selected_bg_color, 0.5);
+#today:selected #date {
+    background-color: @colorAccent;
+    color: #fff;
 }
 
 .cell > #date {


### PR DESCRIPTION
More closely matches the date selection CSS from wingpanel and doesn't interfere so much with event colors

![screenshot from 2018-12-12 15 30 11 2x](https://user-images.githubusercontent.com/7277719/49905555-079f7000-fe23-11e8-9202-0252ac364d3a.png)
