### PR TITLE
Mix instead of alpha/shade for event colors

### DIFF
--- a/data/style/AgendaEventRow.css
+++ b/data/style/AgendaEventRow.css
@@ -1,7 +1,7 @@
 .event {
-    background: alpha(@accent_color, 0.15);
+    background: mix(@accent_color, @base_color, 0.85);
     border-radius: 3px;
-    color: shade(@accent_color, 0.65);
+    color: mix(@accent_color, @fg_color, 0.5);
     padding: 6px;
 }
 
@@ -11,7 +11,7 @@
 }
 
 .cell.dim-label .event {
-    background: alpha (@base_color, 0.7);
+    background: alpha(@base_color, 0.7);
     color: @text_color;
 }
 


### PR DESCRIPTION
Keeps largely the same look, but mixes with theme variables instead of just shading or using alpha. The advantage is that it's more flexible for light-on-dark versus only working for dark-on-light.