### PR TITLE
MainWindow: don't allow editing read-only events

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -128,9 +128,15 @@ public class Maya.MainWindow : Gtk.ApplicationWindow {
     }
 
     private void on_modified (E.CalComponent comp) {
-        var dialog = new Maya.View.EventDialog (comp, null);
-        dialog.transient_for = this;
-        dialog.present ();
+        E.Source src = comp.get_data ("source");
+
+        if (src.writable == true && Model.CalendarModel.get_default ().calclient_is_readonly (src) == false) {
+            var dialog = new Maya.View.EventDialog (comp, null);
+            dialog.transient_for = this;
+            dialog.present ();
+        } else {
+            Gdk.beep ();
+        }
     }
 
     public override bool configure_event (Gdk.EventConfigure event) {


### PR DESCRIPTION
Stops being able to launch an event editing dialog when you activate an event in the grid or agenda views