### PR TITLE
Set color_button_red active when creating a new calendar

### DIFF
--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -244,6 +244,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             event_type = EventType.ADD;
             name_entry.text = "";
             type_combobox.sensitive = true;
+            color_button_red.active = true;
             create_button.set_label (_("Create Calendar"));
         } else {
             event_type = EventType.EDIT;


### PR DESCRIPTION
### BEFORE

![2019-03-29 09 35 09 の画面録画](https://user-images.githubusercontent.com/26003928/55201449-6b994900-5206-11e9-84e4-419265f92cdc.gif)

When you create a new calendar, the red radiobutton (`color_button_red`) is selected for the color of calendar by default. However, once you try to edit existing calendars ("Personal" or "Birthdays & Anniversaries"), no radiobutton is selected (actually an hidden raddiobutton, `color_button_none`, is selected because the color of these calendars is not listed in the default color palette). And then if you try to create a new calendar, the red radiobutton is no longer selected by default, since the hidden radiobutton is still selected.

### AFTER

![2019-03-29 09 36 51 の画面録画](https://user-images.githubusercontent.com/26003928/55201450-6c31df80-5206-11e9-875c-7e3255b8e62d.gif)

This PR explicitly select the red radiobutton when users try to create a new calendar.
