### PR TITLE
Initialize hex_color with default selected red color

### DIFF
--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -24,7 +24,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
 
     private Gtk.Entry name_entry;
     private bool set_as_default = false;
-    private string hex_color;
+    private string hex_color = "#da3d41";
     private Backend current_backend;
     private Gee.Collection<PlacementWidget> backend_widgets;
     private Gtk.Grid main_grid;


### PR DESCRIPTION
### BEFORE

If you try to create a new calendar without changing the color, you can't add a new calendar:

![2019-03-28 12 16 12 の画面録画](https://user-images.githubusercontent.com/26003928/55127472-94acd180-5153-11e9-9069-fef848da5508.gif)

By launching Calendar from Terminal, I got the following error message:

```
** (io.elementary.calendar:17789): CRITICAL **: 12:15:47.198: maya_local_backend_real_add_new_calendar: assertion 'color != NULL' failed
```

However, you can add when you select the color of the calendar explicitly:

![2019-03-28 12 17 39 の画面録画](https://user-images.githubusercontent.com/26003928/55127473-94acd180-5153-11e9-975f-708514dcbd5a.gif)

### AFTER

![2019-03-29 10 09 04 の画面録画](https://user-images.githubusercontent.com/26003928/55202442-c6cd3a80-520a-11e9-9375-627765afacda.gif)

You can create a new calendar even if you don't change the color.
