### PR TITLE
Set contrasting foreground on checkboxes

### DIFF
--- a/src/SourceDialog/SourceItem.vala
+++ b/src/SourceDialog/SourceItem.vala
@@ -166,7 +166,13 @@ public class Maya.View.SourceItem : Gtk.ListBoxRow {
     }
 
     private void style_calendar_color (string color) {
-        var css_color = "@define-color colorAccent %s;".printf (color);
+        Gdk.RGBA check_color = { 0.0, 0.0, 0.0, 1.0 };
+        check_color.parse (color);
+
+        var css_color = "@define-color colorAccent %s; check { color: %s }".printf (
+            color,
+            Granite.contrasting_foreground_color (check_color).to_string ()
+        );
 
         var style_provider = new Gtk.CssProvider ();
 


### PR DESCRIPTION
Attempts to fix #394 but… I don't really like it. The mixed white and black checks look strange.

![Screenshot from 2019-05-13 13 14 18@2x](https://user-images.githubusercontent.com/611168/57647748-0b295580-7581-11e9-82ac-c7df8c0a574c.png)
