### PR TITLE
Reset AgendaView items when parameters change

### DIFF
--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -359,11 +359,11 @@ public class Maya.View.AgendaView : Gtk.ScrolledWindow {
         GLib.List<weak Gtk.Widget> selected_date_events_children = selected_date_events_list.get_children ();
         GLib.List<weak Gtk.Widget> upcoming_events_children = upcoming_events_list.get_children ();
 
-        foreach (var row in selected_date_events_children) {
+        foreach (unowned Gtk.Widget row in selected_date_events_children) {
             row.destroy ();
         }
 
-        foreach (var row in upcoming_events_children) {
+        foreach (unowned Gtk.Widget row in upcoming_events_children) {
             row.destroy ();
         }
     }

--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -111,6 +111,7 @@ public class Maya.View.AgendaView : Gtk.ScrolledWindow {
         calmodel.events_added.connect (on_events_added);
         calmodel.events_removed.connect (on_events_removed);
         calmodel.events_updated.connect (on_events_updated);
+        calmodel.parameters_changed.connect (on_params_changed);
         set_selected_date (Settings.SavedState.get_default ().get_selected ());
         show_all ();
 
@@ -348,6 +349,22 @@ public class Maya.View.AgendaView : Gtk.ScrolledWindow {
                     return GLib.Source.REMOVE;
                 });
             }
+        }
+    }
+
+    /**
+     * Calendar model parameters have been updated.
+     */
+    private void on_params_changed () {
+        GLib.List<weak Gtk.Widget> selected_date_events_children = selected_date_events_list.get_children ();
+        GLib.List<weak Gtk.Widget> upcoming_events_children = upcoming_events_list.get_children ();
+
+        foreach (var row in selected_date_events_children) {
+            row.destroy ();
+        }
+
+        foreach (var row in upcoming_events_children) {
+            row.destroy ();
         }
     }
 

--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -111,7 +111,7 @@ public class Maya.View.AgendaView : Gtk.ScrolledWindow {
         calmodel.events_added.connect (on_events_added);
         calmodel.events_removed.connect (on_events_removed);
         calmodel.events_updated.connect (on_events_updated);
-        calmodel.parameters_changed.connect (on_params_changed);
+        calmodel.parameters_changed.connect (on_model_parameters_changed);
         set_selected_date (Settings.SavedState.get_default ().get_selected ());
         show_all ();
 
@@ -355,7 +355,7 @@ public class Maya.View.AgendaView : Gtk.ScrolledWindow {
     /**
      * Calendar model parameters have been updated.
      */
-    private void on_params_changed () {
+    private void on_model_parameters_changed () {
         GLib.List<weak Gtk.Widget> selected_date_events_children = selected_date_events_list.get_children ();
         GLib.List<weak Gtk.Widget> upcoming_events_children = upcoming_events_list.get_children ();
 


### PR DESCRIPTION
Fixes #452 

When the month or year is changed on the calendar the new parameters cause the source to be reloaded, this will trigger on_events_added but not on_events_removed. To handle this I have connected to parameters_changed and delete existing rows, this is similar to the handling in the CalendarView although that runs on idle removing events and then syncing with the model, such a implementation here would require quite complex handling here to avoid duplication from the subsequent on_events_added signal.