### PR TITLE
Stop more label becoming white when selected

### DIFF
--- a/data/style/Grid.css
+++ b/data/style/Grid.css
@@ -20,6 +20,7 @@
     border-radius: 0;
     border-top: solid 1px @menu_separator;
     border-left: solid 1px @menu_separator;
+    color: @fg_color;
 }
 
 .cell:dir(rtl) {


### PR DESCRIPTION
Fixes #399 

The more label was set to white by the elementary stylesheet when selected, this sets text colour for cell as @fg_color and so it stays visible when selected.