### PR TITLE
Add "Duplicate" to the context menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *~
 build/
+.buildconfig
+.kdev4/
+*.kdev4

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -137,6 +137,26 @@ public class Maya.MainWindow : Gtk.ApplicationWindow {
         }
     }
 
+    public void on_duplicate (ECal.Component comp) {
+        E.Source src = comp.get_data ("source");
+
+        if (src.writable == true && Model.CalendarModel.get_default ().calclient_is_readonly (src) == false) {
+            // The event editor dialog (EventDialog) uses its date/time parameter to tell
+            // if we're editing an existing event (parameter is null) or creating a new one
+            // (parameter is not null). Since here we're creating a new event as a copy of
+            // an existing one, we have to pass that event's date/time.
+            DateTime from_date, _;
+            Util.get_local_datetimes_from_icalcomponent (comp.get_icalcomponent (), out from_date, out _);
+
+            // Now open the editor dialog.
+            var dialog = new Maya.View.EventDialog (comp, from_date);
+            dialog.transient_for = this;
+            dialog.present ();
+        } else {
+            Gdk.beep ();
+        }
+    }
+
     public override bool configure_event (Gdk.EventConfigure event) {
         if (configure_id != 0) {
             GLib.Source.remove (configure_id);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -140,7 +140,7 @@ public class Maya.MainWindow : Gtk.ApplicationWindow {
     public void on_duplicate (ECal.Component comp) {
         E.Source src = comp.get_data ("source");
 
-        if (src.writable == true && Model.CalendarModel.get_default ().calclient_is_readonly (src) == false) {
+        if (src.writable && ! Model.CalendarModel.get_default ().calclient_is_readonly (src)) {
             // The event editor dialog (EventDialog) uses its date/time parameter to tell
             // if we're editing an existing event (parameter is null) or creating a new one
             // (parameter is not null). Since here we're creating a new event as a copy of

--- a/src/Widgets/EventMenu.vala
+++ b/src/Widgets/EventMenu.vala
@@ -5,12 +5,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
@@ -29,7 +29,7 @@ public class Maya.EventMenu : Gtk.Menu {
 
     construct {
         E.Source src = comp.get_data ("source");
-        bool can_modify_cal = Model.CalendarModel.get_default ().calclient_is_readonly (src) == false;
+        bool can_modify_cal = ! Model.CalendarModel.get_default ().calclient_is_readonly (src);
         bool sensitive = src.writable && can_modify_cal;
 
         var edit_item = new Gtk.MenuItem.with_label (_("Edit…"));

--- a/src/Widgets/EventMenu.vala
+++ b/src/Widgets/EventMenu.vala
@@ -51,7 +51,7 @@ public class Maya.EventMenu : Gtk.Menu {
         remove_item.sensitive = sensitive;
         remove_item.activate.connect (remove_event);
 
-        var dup_item = new Gtk.MenuItem.with_label (_("Duplicate"));
+        var dup_item = new Gtk.MenuItem.with_label (_("Duplicate…"));
         dup_item.sensitive = can_modify_cal;
 
         append (remove_item);
@@ -80,9 +80,8 @@ public class Maya.EventMenu : Gtk.Menu {
         var dup = comp;
         dup.set_uid (uid);
 
-        // Store the duplicated event in the calendar
-        var calmodel = Model.CalendarModel.get_default ();
-        calmodel.add_event (comp.get_data<E.Source> ("source"), dup);
+        // Open the new event in the editor
+        ((Maya.Application) GLib.Application.get_default ()).window.on_duplicate (dup);
     }
 
     private void add_exception () {


### PR DESCRIPTION
Creates an exact duplicate of an existing calendar item (same contents, same calendar). The same feature exists  in the macOS Calendar application.

![Screenshot from 2019-12-15 17 20 30](https://user-images.githubusercontent.com/25565229/70865598-99bee480-1f5f-11ea-81c5-93b89cc95e54.png)

Fixes #475