### PR TITLE
Avoid repating event time if end equals start

### DIFF
--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -176,7 +176,7 @@ namespace Maya.Util {
     }
 
     public bool is_same_time (DateTime dtstart, DateTime dtend) {
-        return dstart.equal(dtend);
+        return dtstart.equal(dtend);
     }
 
     public DateTime get_start_of_month (owned DateTime? date = null) {

--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -176,7 +176,7 @@ namespace Maya.Util {
     }
 
     public bool is_same_time (DateTime dtstart, DateTime dtend) {
-        return dtstart.equal(dtend);
+        return dtstart.equal (dtend);
     }
 
     public DateTime get_start_of_month (owned DateTime? date = null) {

--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -175,10 +175,6 @@ namespace Maya.Util {
         }
     }
 
-    public bool is_same_time (DateTime dtstart, DateTime dtend) {
-        return dtstart.equal (dtend);
-    }
-
     public DateTime get_start_of_month (owned DateTime? date = null) {
         if (date == null)
             date = new DateTime.now_local ();

--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -175,6 +175,10 @@ namespace Maya.Util {
         }
     }
 
+    public bool is_same_time (DateTime dtstart, DateTime dtend) {
+        return dstart.equal(dtend);
+    }
+
     public DateTime get_start_of_month (owned DateTime? date = null) {
         if (date == null)
             date = new DateTime.now_local ();

--- a/src/EventEdition/InfoPanel.vala
+++ b/src/EventEdition/InfoPanel.vala
@@ -400,7 +400,7 @@ public class Maya.View.EventEdition.InfoPanel : Gtk.Grid {
 
                 if (start_time.get_hour () == end_time.get_hour ()) {
                     // Same hour, compare minutes
-                    return start_time.get_minute () < end_time.get_minute ();
+                    return start_time.get_minute () <= end_time.get_minute ();
                 }
 
                 // Different hour, start should be smaller

--- a/src/Widgets/AgendaEventRow.vala
+++ b/src/Widgets/AgendaEventRow.vala
@@ -300,7 +300,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
         string end_time_string = end_date.format (Settings.time_format ());
         string? datetime_string = null;
 
-        var is_same_time = start_date_string == end_date_string;
+        var is_same_time = start_time_string == end_time_string;
 
         datatime_label.show ();
         datatime_label.no_show_all = false;

--- a/src/Widgets/AgendaEventRow.vala
+++ b/src/Widgets/AgendaEventRow.vala
@@ -33,6 +33,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
     public string summary { public get; private set; }
     public bool is_allday { public get; private set; default = false; }
     public bool is_multiday { public get; private set; default = false; }
+    public bool is_same_time { public get; private set; default = false; }
     public Gtk.Revealer revealer { public get; private set; }
 
     private Gtk.Image event_image;
@@ -318,7 +319,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
                 } else {
                     if (is_same_time){
                         // TRANSLATORS: A single time i.e. "7:00 PM"
-                        datetime_string = C_("%s").printf (start_time_string);
+                        datetime_string = _("%s").printf (start_time_string);
                     } else {
                         // TRANSLATORS: A range from start time to end time i.e. "7:00 PM – 9:00 PM"
                         datetime_string = C_("time-range", "%s – %s").printf (start_time_string, end_time_string);
@@ -330,7 +331,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
                 } else {
                     if (is_same_time){
                         // TRANSLATORS: A single time from the start date i.e. "Friday, Dec 21, 7"00 PM"
-                        datetime_string = C_("%s, %s").printf (start_date_string, start_time_string);
+                        datetime_string = _("%s, %s").printf (start_date_string, start_time_string);
                     } else {
                         // TRANSLATORS: A range from start date and time to end time i.e. "Friday, Dec 21, 7:00 PM – 9:00 PM"
                         datetime_string = _("%s, %s – %s").printf (start_date_string, start_time_string, end_time_string);

--- a/src/Widgets/AgendaEventRow.vala
+++ b/src/Widgets/AgendaEventRow.vala
@@ -291,6 +291,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
 
         is_allday = Util.is_all_day (start_date, end_date);
         is_multiday = Util.is_multiday_event (ical_event);
+        is_same_time = Util.is_same_time (start_date, end_date);
 
         var date_format = Granite.DateTime.get_default_date_format (true, true, false);
         string start_date_string = start_date.format (date_format);
@@ -315,15 +316,25 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
                     datatime_label.hide ();
                     datatime_label.no_show_all = true;
                 } else {
-                    // TRANSLATORS: A range from start time to end time i.e. "7:00 PM – 9:00 PM"
-                    datetime_string = C_("time-range", "%s – %s").printf (start_time_string, end_time_string);
+                    if (is_same_time){
+                        // TRANSLATORS: A single time i.e. "7:00 PM"
+                        datetime_string = C_("%s").printf (start_time_string);
+                    } else {
+                        // TRANSLATORS: A range from start time to end time i.e. "7:00 PM – 9:00 PM"
+                        datetime_string = C_("time-range", "%s – %s").printf (start_time_string, end_time_string);
+                    }
                 }
             } else {
                 if (is_allday) {
                     datetime_string = "%s".printf (start_date_string);
                 } else {
-                    // TRANSLATORS: A range from start date and time to end time i.e. "Friday, Dec 21, 7:00 PM – 9:00 PM"
-                    datetime_string = _("%s, %s – %s").printf (start_date_string, start_time_string, end_time_string);
+                    if (is_same_time){
+                        // TRANSLATORS: A single time from the start date i.e. "Friday, Dec 21, 7"00 PM"
+                        datetime_string = C_("%s, %s").printf (start_date_string, start_time_string);
+                    } else {
+                        // TRANSLATORS: A range from start date and time to end time i.e. "Friday, Dec 21, 7:00 PM – 9:00 PM"
+                        datetime_string = _("%s, %s – %s").printf (start_date_string, start_time_string, end_time_string);
+                    }
                 }
             }
         }

--- a/src/Widgets/AgendaEventRow.vala
+++ b/src/Widgets/AgendaEventRow.vala
@@ -33,7 +33,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
     public string summary { public get; private set; }
     public bool is_allday { public get; private set; default = false; }
     public bool is_multiday { public get; private set; default = false; }
-    public bool is_same_time { public get; private set; default = false; }
+
     public Gtk.Revealer revealer { public get; private set; }
 
     private Gtk.Image event_image;
@@ -292,7 +292,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
 
         is_allday = Util.is_all_day (start_date, end_date);
         is_multiday = Util.is_multiday_event (ical_event);
-        is_same_time = Util.is_same_time (start_date, end_date);
+        var is_same_time = start_date.equals (end_date);
 
         var date_format = Granite.DateTime.get_default_date_format (true, true, false);
         string start_date_string = start_date.format (date_format);
@@ -318,8 +318,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
                     datatime_label.no_show_all = true;
                 } else {
                     if (is_same_time) {
-                        // TRANSLATORS: A single time i.e. "7:00 PM"
-                        datetime_string = _("%s").printf (start_time_string);
+                        datetime_string = start_time_string;
                     } else {
                         // TRANSLATORS: A range from start time to end time i.e. "7:00 PM – 9:00 PM"
                         datetime_string = C_("time-range", "%s – %s").printf (start_time_string, end_time_string);
@@ -330,8 +329,8 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
                     datetime_string = "%s".printf (start_date_string);
                 } else {
                     if (is_same_time) {
-                        // TRANSLATORS: A single time from the start date i.e. "Friday, Dec 21, 7"00 PM"
-                        datetime_string = _("%s, %s").printf (start_date_string, start_time_string);
+                        // TRANSLATORS: A single time from the start date i.e. "Friday, Dec 21 at 7:00 PM"
+                        datetime_string = _("%s at %s").printf (start_date_string, start_time_string);
                     } else {
                         // TRANSLATORS: A range from start date and time to end time i.e. "Friday, Dec 21, 7:00 PM – 9:00 PM"
                         datetime_string = _("%s, %s – %s").printf (start_date_string, start_time_string, end_time_string);

--- a/src/Widgets/AgendaEventRow.vala
+++ b/src/Widgets/AgendaEventRow.vala
@@ -292,7 +292,6 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
 
         is_allday = Util.is_all_day (start_date, end_date);
         is_multiday = Util.is_multiday_event (ical_event);
-        var is_same_time = start_date.equal (end_date);
 
         var date_format = Granite.DateTime.get_default_date_format (true, true, false);
         string start_date_string = start_date.format (date_format);
@@ -300,6 +299,8 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
         string start_time_string = start_date.format (Settings.time_format ());
         string end_time_string = end_date.format (Settings.time_format ());
         string? datetime_string = null;
+
+        var is_same_time = start_date_string == end_date_string;
 
         datatime_label.show ();
         datatime_label.no_show_all = false;

--- a/src/Widgets/AgendaEventRow.vala
+++ b/src/Widgets/AgendaEventRow.vala
@@ -317,7 +317,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
                     datatime_label.hide ();
                     datatime_label.no_show_all = true;
                 } else {
-                    if (is_same_time){
+                    if (is_same_time) {
                         // TRANSLATORS: A single time i.e. "7:00 PM"
                         datetime_string = _("%s").printf (start_time_string);
                     } else {
@@ -329,7 +329,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
                 if (is_allday) {
                     datetime_string = "%s".printf (start_date_string);
                 } else {
-                    if (is_same_time){
+                    if (is_same_time) {
                         // TRANSLATORS: A single time from the start date i.e. "Friday, Dec 21, 7"00 PM"
                         datetime_string = _("%s, %s").printf (start_date_string, start_time_string);
                     } else {

--- a/src/Widgets/AgendaEventRow.vala
+++ b/src/Widgets/AgendaEventRow.vala
@@ -292,7 +292,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
 
         is_allday = Util.is_all_day (start_date, end_date);
         is_multiday = Util.is_multiday_event (ical_event);
-        var is_same_time = start_date.equals (end_date);
+        var is_same_time = start_date.equal (end_date);
 
         var date_format = Granite.DateTime.get_default_date_format (true, true, false);
         string start_date_string = start_date.format (date_format);


### PR DESCRIPTION
Fixes #463

Small fix to avoid repeating the same time for an event. However, the app didn't allow to create events with the same time in the start and in the end, so a small change was made there too.