### PR TITLE
release 5.0.4

### DIFF
--- a/data/io.elementary.calendar.appdata.xml.in
+++ b/data/io.elementary.calendar.appdata.xml.in
@@ -13,7 +13,7 @@
     </p>
   </description>
   <releases>
-    <release version="5.0.4" date="2020-03-23" urgency="medium">
+    <release version="5.0.4" date="2020-04-03" urgency="medium">
       <description>
         <p>Correctly save event reminders</p>
         <p>Ellipsize event participant details if necessary</p>

--- a/data/io.elementary.calendar.appdata.xml.in
+++ b/data/io.elementary.calendar.appdata.xml.in
@@ -15,9 +15,13 @@
   <releases>
     <release version="5.0.4" date="2020-04-03" urgency="medium">
       <description>
-        <p>Correctly save event reminders</p>
-        <p>Ellipsize event participant details if necessary</p>
-        <p>Fix unwanted rescheduling when editing event title</p>
+      <p>Minor Updates:</p>
+      <ul>
+        <li>Correctly save event reminders</li>
+        <li>Ellipsize event participant details if necessary</li>
+        <li>Fix unwanted rescheduling when editing event title</li>
+        <li>Updated translations</li>
+      </ul>
       </description>
     </release>
     <release version="5.0.3" date="2019-11-27" urgency="medium">

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('io.elementary.calendar',
     'c', 'vala',
-    version: '5.0.3'
+    version: '5.0.4'
 )
 
 add_project_arguments('-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()), language: 'c')


### PR DESCRIPTION
https://github.com/elementary/calendar/compare/5.0.3...master

**Changelog:**

<p>Minor Updates:</p>
      <ul>
        <li>Correctly save event reminders</li>
        <li>Ellipsize event participant details if necessary</li>
        <li>Fix unwanted rescheduling when editing event title</li>
        <li>Updated translations</li>
      </ul>