### PR TITLE
Application: lookup schemas recursive

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -33,7 +33,7 @@ namespace Maya {
         static construct {
             saved_state = new GLib.Settings ("io.elementary.calendar.savedstate");
 
-            if (GLib.SettingsSchemaSource.get_default ().lookup ("io.elementary.desktop.wingpanel.datetime", false) != null) {
+            if (GLib.SettingsSchemaSource.get_default ().lookup ("io.elementary.desktop.wingpanel.datetime", true) != null) {
                 wingpanel_settings = new GLib.Settings ("io.elementary.desktop.wingpanel.datetime");
             }
         }


### PR DESCRIPTION
The docs on SettingsSchemaSource get_default say
```
The returned source may actually consist of multiple schema sources from different directories, depending on which directories were given in `XDG_DATA_DIRS` and `GSETTINGS_SCHEMA_DIR`. For this reason, all lookups performed against the default source should probably be done recursively.
```

Without this in NixOS it will not work as intended, as we
have multiple entries in XDG_DATA_DIRS.