### PR TITLE
Fix behavior of removing occurrences of recurrent events

### DIFF
--- a/core/Model/CalendarModel.vala
+++ b/core/Model/CalendarModel.vala
@@ -178,7 +178,14 @@ public class Maya.Model.CalendarModel : Object {
     public void remove_event (E.Source source, ECal.Component event, ECal.ObjModType mod_type) {
         unowned ICal.Component comp = event.get_icalcomponent ();
         string uid = comp.get_uid ();
-        string? rid = event.has_recurrences () ? null : event.get_recurid_as_string ();
+        string? rid = null;
+
+        if (event.has_recurrences()
+                && mod_type != ECal.ObjModType.ALL) {
+            rid = event.get_recurid_as_string();
+            debug (@"Removing recurrent event '$rid'");
+        }
+
         debug (@"Removing event '$uid'");
         ECal.Client client;
         lock (source_client) {

--- a/core/Model/CalendarModel.vala
+++ b/core/Model/CalendarModel.vala
@@ -180,9 +180,9 @@ public class Maya.Model.CalendarModel : Object {
         string uid = comp.get_uid ();
         string? rid = null;
 
-        if (event.has_recurrences()
+        if (event.has_recurrences ()
                 && mod_type != ECal.ObjModType.ALL) {
-            rid = event.get_recurid_as_string();
+            rid = event.get_recurid_as_string ();
             debug (@"Removing recurrent event '$rid'");
         }
 

--- a/core/Model/CalendarModel.vala
+++ b/core/Model/CalendarModel.vala
@@ -180,8 +180,7 @@ public class Maya.Model.CalendarModel : Object {
         string uid = comp.get_uid ();
         string? rid = null;
 
-        if (event.has_recurrences ()
-                && mod_type != ECal.ObjModType.ALL) {
+        if (event.has_recurrences () && mod_type != ECal.ObjModType.ALL) {
             rid = event.get_recurid_as_string ();
             debug (@"Removing recurrent event '$rid'");
         }

--- a/po/extra/mr.po
+++ b/po/extra/mr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-04-03 20:10+0000\n"
-"PO-Revision-Date: 2020-03-26 16:50+0000\n"
+"PO-Revision-Date: 2020-04-06 07:06+0000\n"
 "Last-Translator: Prachi Joshi <josprachi@yahoo.com>\n"
 "Language-Team: Marathi <https://l10n.elementary.io/projects/calendar/extra/"
 "mr/>\n"
@@ -40,7 +40,7 @@ msgstr ""
 
 #: data/io.elementary.calendar.appdata.xml.in:18
 msgid "Minor Updates:"
-msgstr ""
+msgstr "किरकोळ अद्यतने:"
 
 #: data/io.elementary.calendar.appdata.xml.in:20
 msgid "Correctly save event reminders"
@@ -49,12 +49,13 @@ msgstr "कार्यक्रम स्मरणपत्रे योग्�
 #: data/io.elementary.calendar.appdata.xml.in:21
 msgid "Ellipsize event participant details if necessary"
 msgstr ""
+"आवश्यक असल्यास इव्हेंटच्या सहभागाचे तपशीलास लंबवर्तुळाकारात प्रस्तुत करा"
 
 #: data/io.elementary.calendar.appdata.xml.in:22
-#, fuzzy
-#| msgid "Fix crash when editing an event with no location"
 msgid "Fix unwanted rescheduling when editing event title"
-msgstr "स्थान नसलेले कार्यक्रम संपादित करताना येणाऱ्या क्रॅशचे निराकरण करा"
+msgstr ""
+"कार्यक्रमाचे शीर्षक संपादित करताना अवांछित नवीन वेळापत्रक संबंधित समस्यांचे "
+"निराकरण करा"
 
 #: data/io.elementary.calendar.appdata.xml.in:23
 #: data/io.elementary.calendar.appdata.xml.in:43

--- a/src/Widgets/EventMenu.vala
+++ b/src/Widgets/EventMenu.vala
@@ -65,6 +65,6 @@ public class Maya.EventMenu : Gtk.Menu {
 
     private void add_exception () {
         var calmodel = Model.CalendarModel.get_default ();
-        calmodel.remove_event(comp.get_data<E.Source> ("source"), comp, ECal.ObjModType.THIS);
+        calmodel.remove_event (comp.get_data<E.Source> ("source"), comp, ECal.ObjModType.THIS);
     }
 }

--- a/src/Widgets/EventMenu.vala
+++ b/src/Widgets/EventMenu.vala
@@ -66,14 +66,16 @@ public class Maya.EventMenu : Gtk.Menu {
     }
 
     private void add_exception () {
-        ECal.ComponentDateTime? dtstart;
-        GLib.SList<ECal.ComponentDateTime?>? exdate_list;
 #if E_CAL_2_0
+        GLib.SList<ECal.ComponentDateTime?>? exdate_list;
+        ECal.ComponentDateTime? dtstart;
         dtstart = comp.get_dtstart ();
         exdate_list = comp.get_exdates ();
         exdate_list.append (dtstart);
         comp.set_exdates (exdate_list);
 #else
+        GLib.SList<ECal.ComponentDateTime?> exdate_list;
+        ECal.ComponentDateTime dtstart;
         comp.get_dtstart (out dtstart);
         comp.get_exdate_list (out exdate_list);
         exdate_list.append ((owned) dtstart);

--- a/src/Widgets/EventMenu.vala
+++ b/src/Widgets/EventMenu.vala
@@ -53,8 +53,6 @@ public class Maya.EventMenu : Gtk.Menu {
         append (remove_item);
         append (edit_item);
 
-        remove_item.activate.connect (remove_event);
-
         edit_item.activate.connect (() => {
             ((Maya.Application) GLib.Application.get_default ()).window.on_modified (comp);
         });

--- a/src/Widgets/EventMenu.vala
+++ b/src/Widgets/EventMenu.vala
@@ -64,23 +64,7 @@ public class Maya.EventMenu : Gtk.Menu {
     }
 
     private void add_exception () {
-#if E_CAL_2_0
-        GLib.SList<ECal.ComponentDateTime?>? exdate_list;
-        ECal.ComponentDateTime? dtstart;
-        dtstart = comp.get_dtstart ();
-        exdate_list = comp.get_exdates ();
-        exdate_list.append (dtstart);
-        comp.set_exdates (exdate_list);
-#else
-        GLib.SList<ECal.ComponentDateTime?> exdate_list;
-        ECal.ComponentDateTime dtstart;
-        comp.get_dtstart (out dtstart);
-        comp.get_exdate_list (out exdate_list);
-        exdate_list.append ((owned) dtstart);
-        comp.set_exdate_list (exdate_list);
-#endif
-
         var calmodel = Model.CalendarModel.get_default ();
-        calmodel.update_event (comp.get_data<E.Source> ("source"), comp, ECal.ObjModType.ALL);
+        calmodel.remove_event(comp.get_data<E.Source> ("source"), comp, ECal.ObjModType.THIS);
     }
 }

--- a/vapi/libecal-1.2.vapi
+++ b/vapi/libecal-1.2.vapi
@@ -141,7 +141,7 @@ namespace ECal {
 		public void get_description_list (out GLib.SList<ECal.ComponentText> text_list);
 		public void get_dtend (out ECal.ComponentDateTime? dt);
 		public void get_dtstamp (out ICal.Time? t);
-		public void get_dtstart (out ECal.ComponentDateTime? dt);
+		public void get_dtstart (out ECal.ComponentDateTime dt);
 		public void get_due (out ECal.ComponentDateTime? dt);
 		public void get_exdate_list (out GLib.SList<ECal.ComponentDateTime> exdate_list);
 		public void get_exrule_list (out GLib.SList<ICal.Recurrence> recur_list);
@@ -307,7 +307,7 @@ namespace ECal {
 		public weak string cn;
 		public weak string language;
 	}
-	[CCode (cheader_filename = "libecal/libecal.h", free_function = "e_cal_component_free_datetime")]
+	[CCode (cheader_filename = "libecal/libecal.h", free_function = "e_cal_component_free_datetime", has_copy_function = false, has_destroy_function = false)]
 	public struct ComponentDateTime {
 		public ICal.Time? value;
 		public weak string tzid;


### PR DESCRIPTION
Fixes #491

VAPI for `libecal-1.2` was wrong that caused to send address of the pointer instead of the pointer itself. Program was crashing with _Segmentation fault_ due to invalid access to an address. Problem was explained in detail at [this comment](https://github.com/elementary/calendar/issues/491#issuecomment-611752958) of the issue report. Solving VAPI problem revealed another problem which was more dangerous than _Segmentation fault_ error of the problem, that may broke down event of the user. When user selects _Remove occurrence_ menu item, misbehavior occurs and only right-clicked event remains and other occurrences will be deleted. I found that instead of calling `update_event` method to update whole event by adding exception date, we can rely on `remove_event` method in `CalendarModel` to remove instance of the event. Each recurrence instance has its own _recurrence identification_ that `ECal.Client` can use it to remove. After removing an instance, it can be seen from editing panel that `ECal` adds this date as exception date.

### Change log

- `remove_event` method updated in `CalendarModel` to handle removing occurrences of events
-  Fixes an issue that clicking _Remove Event_ from menu calls `remove_event` method twice, `remove_item` menu item handler connected twice later one is removed
- `add_exception` method updated in `EventMenu`, modification of exception dates is removed and instead of `update_event` method, `remove_event` method is called
- `libecal-1.2` VAPI for `get_dtstart` is corrected according to the library's documentation 

### Recommendations

- VAPI for `libecal-1.2` should be investigated deeply for similar inconsistencies between C library and Vala
- Method name for `add_exception` can be updated to `remove_occurrence`

### Revealed New Issues
- After removing occurance, UI shows events inconsistently. Scrolling will update the view and show events correctly. (This issue may appear after fixing the related issue, so new issue report may be added in future after fix is applied)

After removing occurrence of the event (wrong display)
![After removing occurrence](https://user-images.githubusercontent.com/3192210/79042818-954fc300-7c03-11ea-9805-87c5afc971de.png)

After scrolling (correct display)
![After scrolling](https://user-images.githubusercontent.com/3192210/79042847-c3cd9e00-7c03-11ea-81f8-6961adf3e04b.png)

