### PR TITLE
Monthly repeats by the same day should use 'by_month_day' attribute

### DIFF
--- a/src/EventEdition/RepeatPanel.vala
+++ b/src/EventEdition/RepeatPanel.vala
@@ -17,7 +17,7 @@
  * Authored by: Jaap Broekhuizen
  */
 
- public class Maya.View.EventEdition.RepeatPanel : Gtk.Grid {
+public class Maya.View.EventEdition.RepeatPanel : Gtk.Grid {
     private EventDialog parent_dialog;
     private Gtk.Switch repeat_switch;
     private Gtk.ComboBoxText repeat_combobox;

--- a/src/EventEdition/RepeatPanel.vala
+++ b/src/EventEdition/RepeatPanel.vala
@@ -17,7 +17,7 @@
  * Authored by: Jaap Broekhuizen
  */
 
-public class Maya.View.EventEdition.RepeatPanel : Gtk.Grid {
+ public class Maya.View.EventEdition.RepeatPanel : Gtk.Grid {
     private EventDialog parent_dialog;
     private Gtk.Switch repeat_switch;
     private Gtk.ComboBoxText repeat_combobox;
@@ -733,9 +733,9 @@ public class Maya.View.EventEdition.RepeatPanel : Gtk.Grid {
                     var day_of_month = (short)parent_dialog.date_time.get_day_of_month ();
                     array.append_val (day_of_month);
 #if E_CAL_2_0
-                    rrule.set_by_month_array (array);
+                    rrule.set_by_month_day_array (array);
 #else
-                    ICal.Recurrence.set_by_month_array (ref rrule, array);
+                    ICal.Recurrence.set_by_month_day_array (ref rrule, array);
 #endif
                 }
                 break;

--- a/src/EventEdition/RepeatPanel.vala
+++ b/src/EventEdition/RepeatPanel.vala
@@ -303,7 +303,7 @@
             every_radiobutton.active = true;
         }
 
-        if (rrule.get_by_month (0) != ICal.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX) {
+        if (rrule.get_by_month_day (0) != ICal.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX) {
             same_radiobutton.active = true;
         }
     }

--- a/src/EventEdition/RepeatPanel.vala
+++ b/src/EventEdition/RepeatPanel.vala
@@ -297,12 +297,6 @@ public class Maya.View.EventEdition.RepeatPanel : Gtk.Grid {
 
     private void load_monthly_recurrence (ICal.Recurrence rrule) {
         repeat_combobox.active = 2;
-        var by_day = rrule.get_by_day_array ();
-        for (int i = 0; i < by_day.length; i++) {
-            set_every_day (by_day.index (i));
-            every_radiobutton.active = true;
-        }
-
         if (rrule.get_by_month_day (0) != ICal.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX) {
             same_radiobutton.active = true;
         } else {

--- a/vapi/libical.vapi
+++ b/vapi/libical.vapi
@@ -1965,6 +1965,31 @@ namespace ICal {
 				self.by_month[ii] = ICal.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX;
 			}
 		}
+		[CCode (cname = "_vala_icalrecurrencetype_get_by_month_day")]
+		public short get_by_month_day (uint index) {
+			if (index > ICal.Size.BY_MONTHDAY) {
+				return ICal.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX;
+			}
+
+			return by_month_day[index];
+		}
+		[CCode (cname = "_vala_icalrecurrencetype_get_by_month_day_array")]
+		public GLib.Array<short> get_by_month_day_array () {
+			var array = new GLib.Array<short> (false, false, sizeof (short));
+			array.append_vals (by_month_day, ICal.Size.BY_MONTHDAY);
+			return array;
+		}
+		[CCode (cname = "_vala_icalrecurrencetype_set_by_month_day_array")]
+		public static void set_by_month_day_array (ref ICal.Recurrence self, GLib.Array<short> values) {
+			int ii = 0;
+			for (ii = 0; ii < values.length && ii < ICal.Size.BY_MONTHDAY; ii++) {
+				self.by_month_day[ii] = values.index (ii);
+			}
+
+			if (ii < ICal.Size.BY_MONTHDAY) {
+				self.by_month_day[ii] = ICal.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX;
+			}
+		}
 	}
 	[CCode (cheader_filename = "libical/ical.h", cname = "icalreqstattype")]
 	public struct RequestStatusType {


### PR DESCRIPTION
Fixes #487

Monthly repeat of an event by the same day was using `by_month` attribute instead of `by_month_day` attribute in `ICal.Recurrence`. Using `by_month_day` attribute solves the problem.

### Change log

- Monthly repeats by day are now using `by_month_day` attribute
- New methods were added to ICal's VAPI to work on `by_month_day` attribute of the `ICal.Recurrence` according to the documentation of the library