### PR TITLE
Second option for Monthly recurrence is displayed when editing an event

### DIFF
--- a/src/EventEdition/RepeatPanel.vala
+++ b/src/EventEdition/RepeatPanel.vala
@@ -297,14 +297,14 @@ public class Maya.View.EventEdition.RepeatPanel : Gtk.Grid {
 
     private void load_monthly_recurrence (ICal.Recurrence rrule) {
         repeat_combobox.active = 2;
-        var by_day = rrule.get_by_day_array ();
-        for (int i = 0; i < by_day.length; i++) {
-            set_every_day (by_day.index (i));
-            every_radiobutton.active = true;
-        }
-
         if (rrule.get_by_month (0) != ICal.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX) {
             same_radiobutton.active = true;
+        } else {
+            var by_day = rrule.get_by_day (0);
+            if (by_day != ICal.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX) {
+                set_every_day (by_day);
+                every_radiobutton.active = true;
+            }
         }
     }
 

--- a/vapi/libical.vapi
+++ b/vapi/libical.vapi
@@ -1923,6 +1923,14 @@ namespace ICal {
 		public short get_interval () {
 			return this.interval;
 		}
+		[CCode (cname = "_vala_icalrecurrencetype_get_by_dat")]
+		public short get_by_day (uint index) {
+			if (index > ICal.Size.BY_DAY) {
+				return ICal.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX;
+			}
+
+			return by_day[index];
+		}
 		[CCode (cname = "_vala_icalrecurrencetype_get_by_day_array")]
 		public GLib.Array<short> get_by_day_array () {
 			var array = new GLib.Array<short> (false, false, sizeof (short));


### PR DESCRIPTION
Fixes #508 

Second option for the monthly recurring events is displayed wrongly when editing event. Even when event is created with either options. 

### Change log

- Second option's text is updated with first day's value, code was looping over all days which created the issue
- New method added to VAPI for `ICal` to get single value from `by_day` attribute