### PR TITLE
Changed alfa for accent color of background.

### DIFF
--- a/data/style/AgendaEventRow.css
+++ b/data/style/AgendaEventRow.css
@@ -1,5 +1,5 @@
 .event {
-    background: alpha(@accent_color, 0.15);
+    background: alpha(@accent_color, 0.95);
     border-radius: 3px;
     color: shade(@accent_color, 0.65);
     padding: 6px;


### PR DESCRIPTION
It's a continue of #504 PR. I just cherry-picked the commit to `prefer-dark` branch and change target branch to your `prefer-dark`. 
@cassidyjames you told that contrast here is still not great. Maybe I can help you with that? Maybe you have an example of great contrast сombination (light label + dark background around).  I will inspire and make changes to calendar 