### PR TITLE
Add missing palette colors to color button list

### DIFF
--- a/data/style/ColorButton.css
+++ b/data/style/ColorButton.css
@@ -9,7 +9,7 @@
     -gtk-icon-shadow: none;
 }
 
-.color-button.red radio {
+.color-button.strawberry radio {
     background: @STRAWBERRY_300;
 }
 
@@ -17,11 +17,11 @@
     background: @ORANGE_300;
 }
 
-.color-button.yellow radio {
+.color-button.banana radio {
     background: @BANANA_500;
 }
 
-.color-button.green radio {
+.color-button.lime radio {
     background: @LIME_500;
 }
 
@@ -29,11 +29,11 @@
     background: @MINT_500;
 }
 
-.color-button.blue radio {
+.color-button.blueberry radio {
     background: @BLUEBERRY_500;
 }
 
-.color-button.purple radio {
+.color-button.grape radio {
     background: @GRAPE_500;
 }
 
@@ -41,7 +41,7 @@
     background: @BUBBLEGUM_500;
 }
 
-.color-button.brown radio {
+.color-button.cocoa radio {
     background: @COCOA_300;
 }
 

--- a/data/style/ColorButton.css
+++ b/data/style/ColorButton.css
@@ -25,12 +25,20 @@
     background: @LIME_500;
 }
 
+.color-button.mint radio {
+    background: @MINT_500;
+}
+
 .color-button.blue radio {
     background: @BLUEBERRY_500;
 }
 
 .color-button.purple radio {
     background: @GRAPE_500;
+}
+
+.color-button.bubblegum radio {
+    background: @BUBBLEGUM_500;
 }
 
 .color-button.brown radio {

--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -205,7 +205,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
         });
 
         color_button_strawberry.toggled.connect (() => {
-            hex_color = "#da3d41";
+            hex_color = "#ed5353";
         });
 
         color_button_orange.toggled.connect (() => {
@@ -213,11 +213,11 @@ public class Maya.View.SourceDialog : Gtk.Grid {
         });
 
         color_button_banana.toggled.connect (() => {
-            hex_color = "#e6a92a";
+            hex_color = "#f9c440";
         });
 
         color_button_lime.toggled.connect (() => {
-            hex_color = "#81c837";
+            hex_color = "#68b723";
         });
 
         color_button_mint.toggled.connect (() => {
@@ -282,16 +282,16 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             var cal = (E.SourceCalendar)source.get_extension (E.SOURCE_EXTENSION_CALENDAR);
 
             switch (cal.dup_color ()) {
-                case "#da3d41":
+                case "#ed5353":
                     color_button_strawberry.active = true;
                     break;
                 case "#f37329":
                     color_button_orange.active = true;
                     break;
-                case "#e6a92a":
+                case "#f9c440":
                     color_button_banana.active = true;
                     break;
-                case "#81c837":
+                case "#68b723":
                     color_button_lime.active = true;
                     break;
                 case "#28bca3":

--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -111,89 +111,89 @@ public class Maya.View.SourceDialog : Gtk.Grid {
         var color_label = new Gtk.Label (_("Color:"));
         color_label.xalign = 1;
 
-        color_button_red = new Gtk.RadioButton (null);
+        color_button_strawberry = new Gtk.RadioButton (null);
 
-        var color_button_red_context = color_button_red.get_style_context ();
-        color_button_red_context.add_class ("color-button");
-        color_button_red_context.add_class ("red");
-        color_button_red_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        var color_button_strawberry_context = color_button_strawberry.get_style_context ();
+        color_button_strawberry_context.add_class ("color-button");
+        color_button_strawberry_context.add_class ("strawberry");
+        color_button_strawberry_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        color_button_orange = new Gtk.RadioButton.from_widget (color_button_red);
+        color_button_orange = new Gtk.RadioButton.from_widget (color_button_strawberry);
 
         var color_button_orange_context = color_button_orange.get_style_context ();
         color_button_orange_context.add_class ("color-button");
         color_button_orange_context.add_class ("orange");
         color_button_orange_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        color_button_yellow = new Gtk.RadioButton.from_widget (color_button_red);
+        color_button_banana = new Gtk.RadioButton.from_widget (color_button_strawberry);
 
-        var color_button_yellow_context = color_button_yellow.get_style_context ();
-        color_button_yellow_context.add_class ("color-button");
-        color_button_yellow_context.add_class ("yellow");
-        color_button_yellow_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        var color_button_banana_context = color_button_banana.get_style_context ();
+        color_button_banana_context.add_class ("color-button");
+        color_button_banana_context.add_class ("banana");
+        color_button_banana_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        color_button_green = new Gtk.RadioButton.from_widget (color_button_red);
+        color_button_lime = new Gtk.RadioButton.from_widget (color_button_strawberry);
 
-        var color_button_green_context = color_button_green.get_style_context ();
-        color_button_green_context.add_class ("color-button");
-        color_button_green_context.add_class ("green");
-        color_button_green_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        var color_button_lime_context = color_button_lime.get_style_context ();
+        color_button_lime_context.add_class ("color-button");
+        color_button_lime_context.add_class ("lime");
+        color_button_lime_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         
-        color_button_mint = new Gtk.RadioButton.from_widget (color_button_red);
+        color_button_mint = new Gtk.RadioButton.from_widget (color_button_strawberry);
 
         var color_button_mint_context = color_button_mint.get_style_context ();
         color_button_mint_context.add_class ("color-button");
         color_button_mint_context.add_class ("mint");
         color_button_mint_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        color_button_blue = new Gtk.RadioButton.from_widget (color_button_red);
+        color_button_blueberry = new Gtk.RadioButton.from_widget (color_button_strawberry);
 
-        var color_button_blue_context = color_button_blue.get_style_context ();
-        color_button_blue_context.add_class ("color-button");
-        color_button_blue_context.add_class ("blue");
-        color_button_blue_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        var color_button_blueberry_context = color_button_blueberry.get_style_context ();
+        color_button_blueberry_context.add_class ("color-button");
+        color_button_blueberry_context.add_class ("blueberry");
+        color_button_blueberry_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        color_button_purple = new Gtk.RadioButton.from_widget (color_button_red);
+        color_button_grape = new Gtk.RadioButton.from_widget (color_button_strawberry);
 
-        var color_button_purple_context = color_button_purple.get_style_context ();
-        color_button_purple_context.add_class ("color-button");
-        color_button_purple_context.add_class ("purple");
-        color_button_purple_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        var color_button_grape_context = color_button_grape.get_style_context ();
+        color_button_grape_context.add_class ("color-button");
+        color_button_grape_context.add_class ("grape");
+        color_button_grape_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        color_button_bubblegum = new Gtk.RadioButton.from_widget (color_button_red);
+        color_button_bubblegum = new Gtk.RadioButton.from_widget (color_button_strawberry);
 
         var color_button_bubblegum_context = color_button_bubblegum.get_style_context ();
         color_button_bubblegum_context.add_class ("color-button");
         color_button_bubblegum_context.add_class ("bubblegum");
         color_button_bubblegum_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        color_button_brown = new Gtk.RadioButton.from_widget (color_button_red);
+        color_button_cocoa = new Gtk.RadioButton.from_widget (color_button_strawberry);
 
-        var color_button_brown_context = color_button_brown.get_style_context ();
-        color_button_brown_context.add_class ("color-button");
-        color_button_brown_context.add_class ("brown");
-        color_button_brown_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        var color_button_cocoa_context = color_button_cocoa.get_style_context ();
+        color_button_cocoa_context.add_class ("color-button");
+        color_button_cocoa_context.add_class ("cocoa");
+        color_button_cocoa_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        color_button_slate = new Gtk.RadioButton.from_widget (color_button_red);
+        color_button_slate = new Gtk.RadioButton.from_widget (color_button_strawberry);
 
         var color_button_slate_context = color_button_slate.get_style_context ();
         color_button_slate_context.add_class ("color-button");
         color_button_slate_context.add_class ("slate");
         color_button_slate_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        color_button_none = new Gtk.RadioButton.from_widget (color_button_red);
+        color_button_none = new Gtk.RadioButton.from_widget (color_button_strawberry);
 
         var color_grid = new Gtk.Grid ();
         color_grid.column_spacing = 12;
-        color_grid.add (color_button_red);
+        color_grid.add (color_button_strawberry);
         color_grid.add (color_button_orange);
-        color_grid.add (color_button_yellow);
-        color_grid.add (color_button_green);
+        color_grid.add (color_button_banana);
+        color_grid.add (color_button_lime);
         color_grid.add (color_button_mint);
-        color_grid.add (color_button_blue);
-        color_grid.add (color_button_purple);
+        color_grid.add (color_button_blueberry);
+        color_grid.add (color_button_grape);
         color_grid.add (color_button_bubblegum);
-        color_grid.add (color_button_brown);
+        color_grid.add (color_button_cocoa);
         color_grid.add (color_button_slate);
 
         var check_button = new Gtk.CheckButton.with_label (_("Mark as default calendar"));
@@ -202,7 +202,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             set_as_default = !set_as_default;
         });
 
-        color_button_red.toggled.connect (() => {
+        color_button_strawberry.toggled.connect (() => {
             hex_color = "#da3d41";
         });
 
@@ -210,11 +210,11 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             hex_color = "#f37329";
         });
 
-        color_button_yellow.toggled.connect (() => {
+        color_button_banana.toggled.connect (() => {
             hex_color = "#e6a92a";
         });
 
-        color_button_green.toggled.connect (() => {
+        color_button_lime.toggled.connect (() => {
             hex_color = "#81c837";
         });
 
@@ -222,11 +222,11 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             hex_color = "#28bca3";
         });
 
-        color_button_blue.toggled.connect (() => {
+        color_button_blueberry.toggled.connect (() => {
             hex_color = "#3689e6";
         });
 
-        color_button_purple.toggled.connect (() => {
+        color_button_grape.toggled.connect (() => {
             hex_color = "#a56de2";
         });
 
@@ -234,7 +234,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             hex_color = "#de3e80";
         });
 
-        color_button_brown.toggled.connect (() => {
+        color_button_cocoa.toggled.connect (() => {
             hex_color = "#8a715e";
         });
 
@@ -281,31 +281,31 @@ public class Maya.View.SourceDialog : Gtk.Grid {
 
             switch (cal.dup_color ()) {
                 case "#da3d41":
-                    color_button_red.active = true;
+                    color_button_strawberry.active = true;
                     break;
                 case "#f37329":
                     color_button_orange.active = true;
                     break;
                 case "#e6a92a":
-                    color_button_yellow.active = true;
+                    color_button_banana.active = true;
                     break;
                 case "#81c837":
-                    color_button_green.active = true;
+                    color_button_lime.active = true;
                     break;
                 case "#28bca3":
                     color_button_mint.active = true;
                     break;
                 case "#3689e6":
-                    color_button_blue.active = true;
+                    color_button_blueberry.active = true;
                     break;
                 case "#a56de2":
-                    color_button_purple.active = true;
+                    color_button_grape.active = true;
                     break;
                 case "#de3e80":
                     color_button_bubblegum.active = true;
                     break;
                 case "#8a715e":
-                    color_button_brown.active = true;
+                    color_button_cocoa.active = true;
                     break;
                 case "#667885":
                     color_button_slate.active = true;

--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -209,7 +209,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
         });
 
         color_button_orange.toggled.connect (() => {
-            hex_color = "#f37329";
+            hex_color = "#ffa154";
         });
 
         color_button_banana.toggled.connect (() => {
@@ -285,7 +285,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
                 case "#ed5353":
                     color_button_strawberry.active = true;
                     break;
-                case "#f37329":
+                case "#ffa154":
                     color_button_orange.active = true;
                     break;
                 case "#f9c440":

--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -24,7 +24,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
 
     private Gtk.Entry name_entry;
     private bool set_as_default = false;
-    private string hex_color = "#da3d41";
+    private string hex_color = "#ed5353";
     private Backend current_backend;
     private Gee.Collection<PlacementWidget> backend_widgets;
     private Gtk.Grid main_grid;

--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -138,7 +138,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
         color_button_lime_context.add_class ("color-button");
         color_button_lime_context.add_class ("lime");
         color_button_lime_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-        
+
         color_button_mint = new Gtk.RadioButton.from_widget (color_button_strawberry);
 
         var color_button_mint_context = color_button_mint.get_style_context ();

--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -270,7 +270,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             event_type = EventType.ADD;
             name_entry.text = "";
             type_combobox.sensitive = true;
-            color_button_red.active = true;
+            color_button_strawberry.active = true;
             create_button.set_label (_("Create Calendar"));
         } else {
             event_type = EventType.EDIT;

--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -34,13 +34,15 @@ public class Maya.View.SourceDialog : Gtk.Grid {
     private Gtk.ListStore list_store;
     private E.Source source = null;
 
-    private Gtk.RadioButton color_button_red;
+    private Gtk.RadioButton color_button_strawberry;
     private Gtk.RadioButton color_button_orange;
-    private Gtk.RadioButton color_button_yellow;
-    private Gtk.RadioButton color_button_green;
-    private Gtk.RadioButton color_button_blue;
-    private Gtk.RadioButton color_button_purple;
-    private Gtk.RadioButton color_button_brown;
+    private Gtk.RadioButton color_button_banana;
+    private Gtk.RadioButton color_button_lime;
+    private Gtk.RadioButton color_button_mint;
+    private Gtk.RadioButton color_button_blueberry;
+    private Gtk.RadioButton color_button_grape;
+    private Gtk.RadioButton color_button_bubblegum;
+    private Gtk.RadioButton color_button_cocoa;
     private Gtk.RadioButton color_button_slate;
     private Gtk.RadioButton color_button_none;
 

--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -138,6 +138,13 @@ public class Maya.View.SourceDialog : Gtk.Grid {
         color_button_green_context.add_class ("color-button");
         color_button_green_context.add_class ("green");
         color_button_green_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        
+        color_button_mint = new Gtk.RadioButton.from_widget (color_button_red);
+
+        var color_button_mint_context = color_button_mint.get_style_context ();
+        color_button_mint_context.add_class ("color-button");
+        color_button_mint_context.add_class ("mint");
+        color_button_mint_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         color_button_blue = new Gtk.RadioButton.from_widget (color_button_red);
 
@@ -152,6 +159,13 @@ public class Maya.View.SourceDialog : Gtk.Grid {
         color_button_purple_context.add_class ("color-button");
         color_button_purple_context.add_class ("purple");
         color_button_purple_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        color_button_bubblegum = new Gtk.RadioButton.from_widget (color_button_red);
+
+        var color_button_bubblegum_context = color_button_bubblegum.get_style_context ();
+        color_button_bubblegum_context.add_class ("color-button");
+        color_button_bubblegum_context.add_class ("bubblegum");
+        color_button_bubblegum_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         color_button_brown = new Gtk.RadioButton.from_widget (color_button_red);
 
@@ -175,8 +189,10 @@ public class Maya.View.SourceDialog : Gtk.Grid {
         color_grid.add (color_button_orange);
         color_grid.add (color_button_yellow);
         color_grid.add (color_button_green);
+        color_grid.add (color_button_mint);
         color_grid.add (color_button_blue);
         color_grid.add (color_button_purple);
+        color_grid.add (color_button_bubblegum);
         color_grid.add (color_button_brown);
         color_grid.add (color_button_slate);
 
@@ -202,12 +218,20 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             hex_color = "#81c837";
         });
 
+        color_button_mint.toggled.connect (() => {
+            hex_color = "#28bca3";
+        });
+
         color_button_blue.toggled.connect (() => {
             hex_color = "#3689e6";
         });
 
         color_button_purple.toggled.connect (() => {
             hex_color = "#a56de2";
+        });
+
+        color_button_bubblegum.toggled.connect (() => {
+            hex_color = "#de3e80";
         });
 
         color_button_brown.toggled.connect (() => {
@@ -268,11 +292,17 @@ public class Maya.View.SourceDialog : Gtk.Grid {
                 case "#81c837":
                     color_button_green.active = true;
                     break;
+                case "#28bca3":
+                    color_button_mint.active = true;
+                    break;
                 case "#3689e6":
                     color_button_blue.active = true;
                     break;
                 case "#a56de2":
                     color_button_purple.active = true;
+                    break;
+                case "#de3e80":
+                    color_button_bubblegum.active = true;
                     break;
                 case "#8a715e":
                     color_button_brown.active = true;


### PR DESCRIPTION
Superseded by https://github.com/elementary/calendar/pull/538

Additional improvements in the context of this PR:
- Consistent use of color names based on the official color palette for existing CSS classes and variable names.
- Bringing up the question regarding the need for WCAG compliance.