### PR TITLE
Calendar.Store: Update for pot/POTFILES

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -3,7 +3,13 @@ core/Backends/BackendsManager.vala
 core/Backends/LocalBackend.vala
 core/Backends/PlacementWidget.vala
 core/Model/CalendarModel.vala
-core/DateRange.vala
+core/Services/Calendar/Util/DateIterator.vala
+core/Services/Calendar/Util/DateRange.vala
+core/Services/Calendar/Util/DateTime.vala
+core/Services/Calendar/Util/ECalComponent.vala
+core/Services/Calendar/Util/ESource.vala
+core/Services/Calendar/Util/ICalComponent.vala
+core/Services/Calendar/Util/ICalTime.vala
 core/Utils.vala
 core/GesturesUtils.vala
 daemon/Daemon.vala


### PR DESCRIPTION
One of multiple PR's to break [Calendar.Store](https://github.com/elementary/calendar/pull/549) down in smaller chunks to make review easier. This one contains:

- Added missing files to `pot/POTFILES` and dropped no longer needed ones