### PR TITLE
Calendar.Store: Renamed Maya.Model.CalendarModel to Calendar.Store

### DIFF
--- a/core/GesturesUtils.vala
+++ b/core/GesturesUtils.vala
@@ -6,12 +6,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
@@ -36,7 +36,7 @@ namespace Maya.GesturesUtils {
 
         // It's mouse scroll !
         if (choice == 1 || choice == -1) {
-            Model.CalendarModel.get_default ().change_month ((int) choice);
+            Calendar.Store.get_default ().change_month ((int) choice);
             return true;
         }
 
@@ -46,13 +46,13 @@ namespace Maya.GesturesUtils {
 
         if (choice > 0.3) {
             reset_timer.begin ();
-            Model.CalendarModel.get_default ().change_month (1);
+            Calendar.Store.get_default ().change_month (1);
             return true;
         }
 
         if (choice < -0.3) {
             reset_timer.begin ();
-            Model.CalendarModel.get_default ().change_month (-1);
+            Calendar.Store.get_default ().change_month (-1);
             return true;
         }
 

--- a/core/Services/Calendar/Store.vala
+++ b/core/Services/Calendar/Store.vala
@@ -12,7 +12,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-public class Maya.Model.CalendarModel : Object {
+public class Calendar.Store : Object {
 
     /* The data_range is the range of dates for which this model is storing
      * data. The month_range is a subset of this range corresponding to the
@@ -59,20 +59,20 @@ public class Maya.Model.CalendarModel : Object {
     public GLib.Queue<E.Source> calendar_trash;
     private E.CredentialsPrompter credentials_prompter;
 
-    private static Maya.Model.CalendarModel? calendar_model = null;
+    private static Calendar.Store? store = null;
     private static GLib.Settings state_settings;
 
-    public static CalendarModel get_default () {
-        if (calendar_model == null)
-            calendar_model = new CalendarModel ();
-        return calendar_model;
+    public static Calendar.Store get_default () {
+        if (store == null)
+            store = new Calendar.Store ();
+        return store;
     }
 
     static construct {
         state_settings = new GLib.Settings ("io.elementary.calendar.savedstate");
     }
 
-    private CalendarModel () {
+    private Store () {
         int week_start = Posix.NLTime.FIRST_WEEKDAY.to_string ().data[0];
         if (week_start >= 1 && week_start <= 7) {
             week_starts_on = (GLib.DateWeekday) (week_start - 1);
@@ -82,7 +82,7 @@ public class Maya.Model.CalendarModel : Object {
         compute_ranges ();
 
         source_client = new HashTable<string, ECal.Client> (str_hash, str_equal);
-        source_events = new HashTable<E.Source, Gee.TreeMultiMap<string, ECal.Component>> (Util.source_hash_func, Calendar.Util.esource_equal_func);
+        source_events = new HashTable<E.Source, Gee.TreeMultiMap<string, ECal.Component>> (Maya.Util.source_hash_func, Calendar.Util.esource_equal_func);
         source_view = new HashTable<string, ECal.ClientView> (str_hash, str_equal);
         calendar_trash = new GLib.Queue<E.Source> ();
 

--- a/core/Utils.vala
+++ b/core/Utils.vala
@@ -36,7 +36,7 @@ namespace Maya.Util {
      * E.Source Utils
      */
     public string get_source_location (E.Source source) {
-        var registry = Maya.Model.CalendarModel.get_default ().registry;
+        var registry = Calendar.Store.get_default ().registry;
         string parent_uid = source.parent;
         E.Source parent_source = source;
         while (parent_source != null) {
@@ -70,7 +70,7 @@ namespace Maya.Util {
      */
 
     public void save_temp_selected_calendars () {
-        var calmodel = Model.CalendarModel.get_default ();
+        var calmodel = Calendar.Store.get_default ();
         var events = calmodel.get_events ();
         var builder = new StringBuilder ();
         builder.append ("BEGIN:VCALENDAR\n");

--- a/core/meson.build
+++ b/core/meson.build
@@ -14,7 +14,7 @@ core_files = files(
     'Backends/BackendsManager.vala',
     'Backends/LocalBackend.vala',
     'Backends/PlacementWidget.vala',
-    'Model/CalendarModel.vala',
+    'Services/Calendar/Store.vala',
     'Services/Calendar/Util/DateIterator.vala',
     'Services/Calendar/Util/DateRange.vala',
     'Services/Calendar/Util/DateTime.vala',

--- a/daemon/Daemon.vala
+++ b/daemon/Daemon.vala
@@ -43,7 +43,7 @@ namespace Maya {
 
         private void load_today_events () {
             event_uid = new Gee.HashMap<ECal.Component, string> ();
-            var model = Maya.Model.CalendarModel.get_default ();
+            var model = Calendar.Store.get_default ();
             model.events_added.connect (on_events_added);
             model.events_updated.connect (on_events_updated);
             model.events_removed.connect (on_events_removed);

--- a/plugins/CalDAV/CalDAVBackend.vala
+++ b/plugins/CalDAV/CalDAVBackend.vala
@@ -164,7 +164,7 @@ public class Maya.CalDavBackend : GLib.Object, Maya.Backend {
                 }
             }
 
-            var calmodel = Maya.Model.CalendarModel.get_default ();
+            var calmodel = Calendar.Store.get_default ();
             var registry = calmodel.registry;
             var list = new List<E.Source> ();
             list.append (new_source);

--- a/plugins/Google/GoogleBackend.vala
+++ b/plugins/Google/GoogleBackend.vala
@@ -96,7 +96,7 @@ public class Maya.GoogleBackend : GLib.Object, Maya.Backend {
                 }
             }
 
-            var calmodel = Maya.Model.CalendarModel.get_default ();
+            var calmodel = Calendar.Store.get_default ();
             var registry = calmodel.registry;
             var list = new List<E.Source> ();
             list.append (new_source);

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -2,7 +2,7 @@ core/Backends/Backend.vala
 core/Backends/BackendsManager.vala
 core/Backends/LocalBackend.vala
 core/Backends/PlacementWidget.vala
-core/Model/CalendarModel.vala
+core/Services/Calendar/Store.vala
 core/Services/Calendar/Util/DateIterator.vala
 core/Services/Calendar/Util/DateRange.vala
 core/Services/Calendar/Util/DateTime.vala

--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -107,7 +107,7 @@ public class Maya.View.AgendaView : Gtk.ScrolledWindow {
         add (grid);
 
         // Listen to changes for events
-        var calmodel = Model.CalendarModel.get_default ();
+        var calmodel = Calendar.Store.get_default ();
         calmodel.events_added.connect (on_events_added);
         calmodel.events_removed.connect (on_events_removed);
         calmodel.events_updated.connect (on_events_updated);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -75,7 +75,7 @@ namespace Maya {
                 }
             }
 
-            var calmodel = Model.CalendarModel.get_default ();
+            var calmodel = Calendar.Store.get_default ();
             calmodel.load_all_sources ();
 
             init_gui ();
@@ -91,7 +91,7 @@ namespace Maya {
 
         public override void open (File[] files, string hint) {
             if (get_windows () == null) {
-                var calmodel = Model.CalendarModel.get_default ();
+                var calmodel = Calendar.Store.get_default ();
                 calmodel.load_all_sources ();
 
                 init_gui ();
@@ -141,7 +141,7 @@ namespace Maya {
         }
 
         private void on_quit () {
-            Model.CalendarModel.get_default ().delete_trashed_calendars ();
+            Calendar.Store.get_default ().delete_trashed_calendars ();
         }
 
         public static DateTime get_selected_datetime () {

--- a/src/EventEdition/EventDialog.vala
+++ b/src/EventEdition/EventDialog.vala
@@ -187,7 +187,7 @@ public class EventDialog : Gtk.Dialog {
             reminder_panel.save ();
             repeat_panel.save ();
 
-            var calmodel = Model.CalendarModel.get_default ();
+            var calmodel = Calendar.Store.get_default ();
             if (event_type == EventType.ADD)
                 calmodel.add_event (source, ecal);
             else {
@@ -207,7 +207,7 @@ public class EventDialog : Gtk.Dialog {
         }
 
         private void remove_event () {
-            var calmodel = Model.CalendarModel.get_default ();
+            var calmodel = Calendar.Store.get_default ();
             calmodel.remove_event (original_source, ecal, mod_type);
             this.destroy ();
         }

--- a/src/EventEdition/RepeatPanel.vala
+++ b/src/EventEdition/RepeatPanel.vala
@@ -537,7 +537,7 @@ public class Maya.View.EventEdition.RepeatPanel : Gtk.Grid {
         sun_button = new Gtk.ToggleButton.with_label (_("Sun"));
         week_box.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
         week_box.get_style_context ().add_class ("raised");
-        switch (Maya.Model.CalendarModel.get_default ().week_starts_on) {
+        switch (Calendar.Store.get_default ().week_starts_on) {
             case GLib.DateWeekday.TUESDAY:
                 week_box.add (thu_button);
                 week_box.add (fri_button);

--- a/src/Grid/CalendarView.vala
+++ b/src/Grid/CalendarView.vala
@@ -63,7 +63,7 @@ public class Maya.View.CalendarView : Gtk.Grid {
 
         sync_with_model ();
 
-        var model = Model.CalendarModel.get_default ();
+        var model = Calendar.Store.get_default ();
         model.parameters_changed.connect (on_model_parameters_changed);
 
         model.events_added.connect (on_events_added);
@@ -131,7 +131,7 @@ public class Maya.View.CalendarView : Gtk.Grid {
 
     public void today () {
         var today = Calendar.Util.datetime_strip_time (new DateTime.now_local ());
-        var calmodel = Model.CalendarModel.get_default ();
+        var calmodel = Calendar.Store.get_default ();
         var start = Calendar.Util.datetime_get_start_of_month (today);
         if (!start.equal (calmodel.month_start))
             calmodel.month_start = start;
@@ -142,7 +142,7 @@ public class Maya.View.CalendarView : Gtk.Grid {
     //--- Signal Handlers ---//
 
     void on_show_weeks_changed () {
-        var model = Model.CalendarModel.get_default ();
+        var model = Calendar.Store.get_default ();
         weeks.update (model.data_range.first_dt, model.num_weeks);
         update_spacer_visible ();
     }
@@ -184,7 +184,7 @@ public class Maya.View.CalendarView : Gtk.Grid {
 
     /* Indicates the month has changed */
     void on_model_parameters_changed () {
-        var model = Model.CalendarModel.get_default ();
+        var model = Calendar.Store.get_default ();
         if (grid.grid_range != null && model.data_range.equals (grid.grid_range))
             return; // nothing to do
 
@@ -199,7 +199,7 @@ public class Maya.View.CalendarView : Gtk.Grid {
 
     /* Sets the calendar widgets to the date range of the model */
     void sync_with_model () {
-        var model = Model.CalendarModel.get_default ();
+        var model = Calendar.Store.get_default ();
         if (grid.grid_range != null && (model.data_range.equals (grid.grid_range) || grid.grid_range.first_dt.compare (model.data_range.first_dt) == 0))
             return; // nothing to do
 

--- a/src/Grid/EventButton.vala
+++ b/src/Grid/EventButton.vala
@@ -5,12 +5,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
@@ -67,7 +67,7 @@ public class Maya.View.EventButton : Gtk.Revealer {
             } else if (event.type == Gdk.EventType.BUTTON_PRESS && event.button == Gdk.BUTTON_SECONDARY) {
                 E.Source src = comp.get_data ("source");
 
-                bool sensitive = src.writable == true && Model.CalendarModel.get_default ().calclient_is_readonly (src) == false;
+                bool sensitive = src.writable == true && Calendar.Store.get_default ().calclient_is_readonly (src) == false;
 
                 var menu = new Maya.EventMenu (comp);
                 menu.attach_to_widget (this, null);
@@ -86,7 +86,7 @@ public class Maya.View.EventButton : Gtk.Revealer {
         Gtk.drag_source_set (event_box, Gdk.ModifierType.BUTTON1_MASK, {dnd, dnd2}, Gdk.DragAction.MOVE);
 
         event_box.drag_data_get.connect ( (ctx, sel, info, time) => {
-            Model.CalendarModel.get_default ().drag_component = comp;
+            Calendar.Store.get_default ().drag_component = comp;
             unowned ICal.Component icalcomp = comp.get_icalcomponent ();
             var ical_str = icalcomp.as_ical_string ();
             sel.set_text (ical_str, ical_str.length);

--- a/src/Grid/Grid.vala
+++ b/src/Grid/Grid.vala
@@ -69,7 +69,7 @@ public class Grid : Gtk.Grid {
 
         Maya.Application.saved_state.set_string ("selected-day", selected_date.format ("%Y-%j"));
 
-        var calmodel = Maya.Model.CalendarModel.get_default ();
+        var calmodel = Calendar.Store.get_default ();
         var date_month = selected_date.get_month () - calmodel.month_start.get_month ();
         var date_year = selected_date.get_year () - calmodel.month_start.get_year ();
         if (date_month != 0 || date_year != 0) {

--- a/src/Grid/GridDay.vala
+++ b/src/Grid/GridDay.vala
@@ -6,12 +6,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
@@ -112,7 +112,7 @@ public class Maya.View.GridDay : Gtk.EventBox {
     }
 
     public override void drag_data_received (Gdk.DragContext context, int x, int y, Gtk.SelectionData selection_data, uint info, uint time_) {
-        var calmodel = Model.CalendarModel.get_default ();
+        var calmodel = Calendar.Store.get_default ();
         var comp = calmodel.drag_component;
         unowned ICal.Component icalcomp = comp.get_icalcomponent ();
         E.Source src = comp.get_data ("source");

--- a/src/ImportDialog.vala
+++ b/src/ImportDialog.vala
@@ -5,12 +5,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
@@ -67,7 +67,7 @@ public class Maya.View.ImportDialog : Granite.MessageDialog {
 
     private void import_files () {
         var source = calchooser_button.current_source;
-        var calmodel = Model.CalendarModel.get_default ();
+        var calmodel = Calendar.Store.get_default ();
         foreach (var file in files) {
 #if E_CAL_2_0
             var ical = ECal.util_parse_ics_file (file.get_path ());

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -6,12 +6,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
@@ -98,7 +98,7 @@ public class Maya.MainWindow : Gtk.ApplicationWindow {
 
         Maya.Application.saved_state.bind ("hpaned-position", hpaned, "position", GLib.SettingsBindFlags.DEFAULT);
 
-        Model.CalendarModel.get_default ().error_received.connect ((message) => {
+        Calendar.Store.get_default ().error_received.connect ((message) => {
             Idle.add (() => {
                 infobar_label.label = message;
                 infobar.show ();
@@ -122,13 +122,13 @@ public class Maya.MainWindow : Gtk.ApplicationWindow {
     }
 
     private void on_remove (ECal.Component comp) {
-        Model.CalendarModel.get_default ().remove_event (comp.get_data<E.Source> ("source"), comp, ECal.ObjModType.THIS);
+        Calendar.Store.get_default ().remove_event (comp.get_data<E.Source> ("source"), comp, ECal.ObjModType.THIS);
     }
 
     public void on_modified (ECal.Component comp) {
         E.Source src = comp.get_data ("source");
 
-        if (src.writable == true && Model.CalendarModel.get_default ().calclient_is_readonly (src) == false) {
+        if (src.writable == true && Calendar.Store.get_default ().calclient_is_readonly (src) == false) {
             var dialog = new Maya.View.EventDialog (comp, null);
             dialog.transient_for = this;
             dialog.present ();

--- a/src/SourceDialog/SourceItem.vala
+++ b/src/SourceDialog/SourceItem.vala
@@ -54,7 +54,7 @@ public class Maya.View.SourceItem : Gtk.ListBoxRow {
         visible_checkbutton = new Gtk.CheckButton ();
         visible_checkbutton.active = cal.selected;
         visible_checkbutton.toggled.connect (() => {
-            var calmodel = Model.CalendarModel.get_default ();
+            var calmodel = Calendar.Store.get_default ();
             if (visible_checkbutton.active == true) {
                 calmodel.add_source (source);
             } else {
@@ -142,7 +142,7 @@ public class Maya.View.SourceItem : Gtk.ListBoxRow {
         edit_button.clicked.connect (() => {edit_request (source);});
 
         undo_button.clicked.connect (() => {
-            Model.CalendarModel.get_default ().restore_calendar ();
+            Calendar.Store.get_default ().restore_calendar ();
             stack.set_visible_child_name ("calendar");
         });
 

--- a/src/SourceDialog/SourceSelector.vala
+++ b/src/SourceDialog/SourceSelector.vala
@@ -6,12 +6,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
@@ -165,7 +165,7 @@ public class Maya.View.SourceSelector : Gtk.Popover {
     }
 
     private void remove_source (E.Source source) {
-        Model.CalendarModel.get_default ().trash_calendar (source);
+        Calendar.Store.get_default ().trash_calendar (source);
         var source_item = src_map.get (source.dup_uid ());
         source_item.show_calendar_removed ();
     }

--- a/src/Widgets/CalendarButton.vala
+++ b/src/Widgets/CalendarButton.vala
@@ -43,7 +43,7 @@ public class Maya.View.Widgets.CalendarButton : Gtk.MenuButton {
 
     construct {
         sources = new GLib.List<E.Source> ();
-        var calmodel = Model.CalendarModel.get_default ();
+        var calmodel = Calendar.Store.get_default ();
         var registry = calmodel.registry;
         foreach (var src in registry.list_sources (E.SOURCE_EXTENSION_CALENDAR)) {
             if (src.writable == true && src.enabled == true && calmodel.calclient_is_readonly (src) == false) {

--- a/src/Widgets/DynamicSpinner.vala
+++ b/src/Widgets/DynamicSpinner.vala
@@ -6,12 +6,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
@@ -43,7 +43,7 @@ public class Maya.View.Widgets.DynamicSpinner : Gtk.Revealer {
         button.popover = info_popover;
         button.valign = Gtk.Align.CENTER;
 
-        var calmodel = Model.CalendarModel.get_default ();
+        var calmodel = Calendar.Store.get_default ();
         calmodel.connecting.connect ((source, cancellable) => add_source.begin (source, cancellable));
         calmodel.connected.connect ((source) => remove_source.begin (source));
 

--- a/src/Widgets/EventMenu.vala
+++ b/src/Widgets/EventMenu.vala
@@ -5,12 +5,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
@@ -29,7 +29,7 @@ public class Maya.EventMenu : Gtk.Menu {
 
     construct {
         E.Source src = comp.get_data ("source");
-        bool sensitive = src.writable == true && Model.CalendarModel.get_default ().calclient_is_readonly (src) == false;
+        bool sensitive = src.writable == true && Calendar.Store.get_default ().calclient_is_readonly (src) == false;
 
         var edit_item = new Gtk.MenuItem.with_label (_("Edit…"));
         edit_item.sensitive = sensitive;
@@ -59,12 +59,12 @@ public class Maya.EventMenu : Gtk.Menu {
     }
 
     private void remove_event () {
-        var calmodel = Model.CalendarModel.get_default ();
+        var calmodel = Calendar.Store.get_default ();
         calmodel.remove_event (comp.get_data<E.Source> ("source"), comp, ECal.ObjModType.ALL);
     }
 
     private void add_exception () {
-        var calmodel = Model.CalendarModel.get_default ();
+        var calmodel = Calendar.Store.get_default ();
         calmodel.remove_event (comp.get_data<E.Source> ("source"), comp, ECal.ObjModType.THIS);
     }
 }

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -6,12 +6,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
@@ -57,7 +57,7 @@ namespace Maya.View {
 
             month_switcher = new Widgets.DateSwitcher (10);
             year_switcher = new Widgets.DateSwitcher (-1);
-            var calmodel = Model.CalendarModel.get_default ();
+            var calmodel = Calendar.Store.get_default ();
             set_switcher_date (calmodel.month_start);
 
             var contractor = new Widgets.ContractorButtonWithMenu (_("Export or Share the default Calendar"));
@@ -76,10 +76,10 @@ namespace Maya.View {
             pack_end (menu_button);
             pack_end (contractor);
 
-            month_switcher.left_clicked.connect (() => Model.CalendarModel.get_default ().change_month (-1));
-            month_switcher.right_clicked.connect (() => Model.CalendarModel.get_default ().change_month (1));
-            year_switcher.left_clicked.connect (() => Model.CalendarModel.get_default ().change_year (-1));
-            year_switcher.right_clicked.connect (() => Model.CalendarModel.get_default ().change_year (1));
+            month_switcher.left_clicked.connect (() => Calendar.Store.get_default ().change_month (-1));
+            month_switcher.right_clicked.connect (() => Calendar.Store.get_default ().change_month (1));
+            year_switcher.left_clicked.connect (() => Calendar.Store.get_default ().change_year (-1));
+            year_switcher.right_clicked.connect (() => Calendar.Store.get_default ().change_year (1));
             calmodel.parameters_changed.connect (() => {
                 set_switcher_date (calmodel.month_start);
             });


### PR DESCRIPTION
One of multiple PR's to break [Calendar.Store](https://github.com/elementary/calendar/pull/549) down in smaller chunks to make review easier. This one contains:

- Renamed `Maya.Model.CalendarModel` to `Calendar.Store`