### PR TITLE
Add contextual translations for "Repeat" string

### DIFF
--- a/src/EventEdition/EventDialog.vala
+++ b/src/EventEdition/EventDialog.vala
@@ -120,7 +120,7 @@ public class EventDialog : Gtk.Dialog {
             stack.add_titled (guests_panel, "guestspanel", _("Guests"));
             stack.add_titled (reminder_panel, "reminderpanel", _("Reminders"));
             ///Translators: The name of the repeat panel tab
-            stack.add_titled (repeat_panel, "repeatpanel", _C("Section Header", "Repeat"));
+            stack.add_titled (repeat_panel, "repeatpanel", C_("Section Header", "Repeat")); //vala-lint=space-before-paren
             stack.child_set_property (info_panel, "icon-name", "office-calendar-symbolic");
             stack.child_set_property (location_panel, "icon-name", "mark-location-symbolic");
             stack.child_set_property (guests_panel, "icon-name", "system-users-symbolic");

--- a/src/EventEdition/EventDialog.vala
+++ b/src/EventEdition/EventDialog.vala
@@ -119,7 +119,8 @@ public class EventDialog : Gtk.Dialog {
             stack.add_titled (location_panel, "locationpanel", _("Location"));
             stack.add_titled (guests_panel, "guestspanel", _("Guests"));
             stack.add_titled (reminder_panel, "reminderpanel", _("Reminders"));
-            stack.add_titled (repeat_panel, "repeatpanel", _("Repeat"));
+            ///Translators: The name of the repeat panel tab
+            stack.add_titled (repeat_panel, "repeatpanel", _C("Tab", "Repeat"));
             stack.child_set_property (info_panel, "icon-name", "office-calendar-symbolic");
             stack.child_set_property (location_panel, "icon-name", "mark-location-symbolic");
             stack.child_set_property (guests_panel, "icon-name", "system-users-symbolic");

--- a/src/EventEdition/EventDialog.vala
+++ b/src/EventEdition/EventDialog.vala
@@ -120,7 +120,7 @@ public class EventDialog : Gtk.Dialog {
             stack.add_titled (guests_panel, "guestspanel", _("Guests"));
             stack.add_titled (reminder_panel, "reminderpanel", _("Reminders"));
             ///Translators: The name of the repeat panel tab
-            stack.add_titled (repeat_panel, "repeatpanel", _C("Tab", "Repeat"));
+            stack.add_titled (repeat_panel, "repeatpanel", _C("Section Header", "Repeat"));
             stack.child_set_property (info_panel, "icon-name", "office-calendar-symbolic");
             stack.child_set_property (location_panel, "icon-name", "mark-location-symbolic");
             stack.child_set_property (guests_panel, "icon-name", "system-users-symbolic");

--- a/src/EventEdition/RepeatPanel.vala
+++ b/src/EventEdition/RepeatPanel.vala
@@ -134,6 +134,9 @@ public class Maya.View.EventEdition.RepeatPanel : Gtk.Grid {
 
         var ends_label = new Granite.HeaderLabel (_("Ends:"));
 
+        ///Translators: Give a word to describe an event ending after a certain number of repeats.
+        ///This will be displayed in the format like: "Ends After 2 Repeats",
+        ///where this string always represents the last word in the phrase.
         var end_label = new Gtk.Label (ngettext ("Repeat", "Repeats", 1));
         end_label.no_show_all = true;
 


### PR DESCRIPTION
Fixes #11 

I have no experience with localization, so I hope this is all in an acceptable format. I couldn't find a way to add a context annotation to a plural string, which seems weird. This could interfere in some languages like German, where the noun is in a different case and takes a different form than the default. But at any rate this is an improvement.