### PR TITLE
Fix compiler warning in util_tests

### DIFF
--- a/core/Tests/util-tests.vala
+++ b/core/Tests/util-tests.vala
@@ -211,7 +211,11 @@ int main (string[] args) {
     add_datetime_tests ();
     var result = Test.run ();
 
-    Environment.unset_variable ("TZ");
+    if (original_tz != null) {
+        Environment.set_variable ("TZ", original_tz, true);
+    } else {
+        Environment.unset_variable ("TZ");
+    }
     print ("Resetting $TZ environment variable after testing\n");
     return result;
 }


### PR DESCRIPTION
I messed up how I handled the `$TZ` environment variable reset in `util_tests.vala` in my last PR. The issue shouldn't have any significant impact (it only resets the variable to what it was before, which is local to the shell session anyway) but this fixes it.