### PR TITLE
Fix showing duplicate events when added

### DIFF
--- a/core/Services/Calendar/EventStore.vala
+++ b/core/Services/Calendar/EventStore.vala
@@ -479,10 +479,12 @@ public class Calendar.EventStore : Object {
 #else
             client.generate_instances_for_object_sync (comp, (time_t) data_range.first_dt.to_unix (), (time_t) data_range.last_dt.to_unix (), (event, start, end) => {
 #endif
-                debug_event (source, event, "ADDED");
-                event.set_data<E.Source> ("source", source);
-                events.set (uid, event);
-                added_events.add (event);
+                if (!added_events.contains (event)) {
+                    debug_event (source, event, "ADDED");
+                    event.set_data<E.Source> ("source", source);
+                    events.set (uid, event);
+                    added_events.add (event);
+                }
                 return true;
             });
         });

--- a/core/Services/Calendar/EventStore.vala
+++ b/core/Services/Calendar/EventStore.vala
@@ -485,6 +485,7 @@ public class Calendar.EventStore : Object {
                     events.set (uid, event);
                     added_events.add (event);
                 }
+
                 return true;
             });
         });


### PR DESCRIPTION
Fixes #478 

Re-implements the fix from #560. When an event appears multiple times with the same UID, we only take the first one. This shouldn't catch any recurrences, since those differ by RID, not UID.

A test would be nice, but I don't know how to mock a google backend for this. :man_shrugging: