### PR TITLE
Fix checkbox to set calendar as default

### DIFF
--- a/data/io.elementary.calendar.appdata.xml.in
+++ b/data/io.elementary.calendar.appdata.xml.in
@@ -18,6 +18,7 @@
       <p>Minor Updates:</p>
       <ul>
         <li>Fix an issue where new events could appear twice in Calendar</li>
+        <li>"Mark as default calendar" box is now correctly checked when editing a calendar</li>
       </ul>
       </description>
     </release>

--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -47,7 +47,6 @@ public class Maya.View.SourceDialog : Gtk.Grid {
     public signal void go_back ();
 
     construct {
-        debug ("SourceDialog constructor");
         widgets_checked = new Gee.HashMap<string, bool> (null, null);
 
         var cancel_button = new Gtk.Button.with_label (_("Cancel"));

--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -23,7 +23,6 @@ public class Maya.View.SourceDialog : Gtk.Grid {
     public EventType event_type { get; private set; default=EventType.EDIT;}
 
     private Gtk.Entry name_entry;
-    private bool set_as_default = false;
     private string hex_color = "#da3d41";
     private Backend current_backend;
     private Gee.Collection<PlacementWidget> backend_widgets;
@@ -32,6 +31,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
     private Gtk.Button create_button;
     private Gtk.ComboBox type_combobox;
     private Gtk.ListStore list_store;
+    private Gtk.CheckButton is_default_check;
     private E.Source source = null;
 
     private Gtk.RadioButton color_button_red;
@@ -47,6 +47,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
     public signal void go_back ();
 
     construct {
+        debug ("SourceDialog constructor");
         widgets_checked = new Gee.HashMap<string, bool> (null, null);
 
         var cancel_button = new Gtk.Button.with_label (_("Cancel"));
@@ -180,11 +181,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
         color_grid.add (color_button_brown);
         color_grid.add (color_button_slate);
 
-        var check_button = new Gtk.CheckButton.with_label (_("Mark as default calendar"));
-
-        check_button.toggled.connect (() => {
-            set_as_default = !set_as_default;
-        });
+        is_default_check = new Gtk.CheckButton.with_label (_("Mark as default calendar"));
 
         color_button_red.toggled.connect (() => {
             hex_color = "#da3d41";
@@ -227,7 +224,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
         main_grid.attach (name_entry, 1, 1);
         main_grid.attach (color_label, 0, 2);
         main_grid.attach (color_grid, 1, 2);
-        main_grid.attach (check_button, 1, 3);
+        main_grid.attach (is_default_check, 1, 3);
 
         margin = 12;
         margin_bottom = 8;
@@ -246,6 +243,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             type_combobox.sensitive = true;
             color_button_red.active = true;
             create_button.set_label (_("Create Calendar"));
+            is_default_check.active = false;
         } else {
             event_type = EventType.EDIT;
             create_button.set_label (_("Save"));
@@ -253,6 +251,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             type_combobox.sensitive = false;
             type_combobox.set_active (0);
             list_store.foreach (tree_foreach);
+            is_default_check.active = false;
             var cal = (E.SourceCalendar)source.get_extension (E.SOURCE_EXTENSION_CALENDAR);
 
             switch (cal.dup_color ()) {
@@ -349,10 +348,10 @@ public class Maya.View.SourceDialog : Gtk.Grid {
 
     public void save () {
         if (event_type == EventType.ADD) {
-            current_backend.add_new_calendar (name_entry.text, hex_color, set_as_default, backend_widgets);
+            current_backend.add_new_calendar (name_entry.text, hex_color, is_default_check.active, backend_widgets);
             go_back ();
         } else {
-            current_backend.modify_calendar (name_entry.text, hex_color, set_as_default, backend_widgets, source);
+            current_backend.modify_calendar (name_entry.text, hex_color, is_default_check.active, backend_widgets, source);
             go_back ();
         }
     }

--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -242,6 +242,7 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             type_combobox.sensitive = true;
             color_button_red.active = true;
             create_button.set_label (_("Create Calendar"));
+            is_default_check.sensitive = true;
             is_default_check.active = false;
         } else {
             event_type = EventType.EDIT;
@@ -250,9 +251,19 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             type_combobox.sensitive = false;
             type_combobox.set_active (0);
             list_store.foreach (tree_foreach);
-            is_default_check.active = false;
-            var cal = (E.SourceCalendar)source.get_extension (E.SOURCE_EXTENSION_CALENDAR);
 
+            try {
+                var registry = new E.SourceRegistry.sync (null);
+                var source_is_default = source.equal (registry.default_calendar);
+                debug (@"source_is_default: $source_is_default");
+                // Prevent source from being "unset" as default, which is undefined
+                is_default_check.sensitive = !source_is_default;
+                is_default_check.active = source_is_default;
+            } catch (GLib.Error error) {
+                critical (error.message);
+            }
+
+            var cal = (E.SourceCalendar)source.get_extension (E.SOURCE_EXTENSION_CALENDAR);
             switch (cal.dup_color ()) {
                 case "#da3d41":
                     color_button_red.active = true;

--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -255,7 +255,6 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             try {
                 var registry = new E.SourceRegistry.sync (null);
                 var source_is_default = source.equal (registry.default_calendar);
-                debug (@"source_is_default: $source_is_default");
                 // Prevent source from being "unset" as default, which is undefined
                 is_default_check.sensitive = !source_is_default;
                 is_default_check.active = source_is_default;


### PR DESCRIPTION
Fixes #550 

This keeps the state of the check button to set a calendar as default in the right state. When you open the calendar edit dialog, it always reverts to unchecked, and checking it will tell Calendar to make that calendar the default. If it's not checked, then nothing happens and the default calendar stays as is.

I'm not convinced this is a great design, but it at least fixes the issues we had before. It means that (outside of what appears when you create a new event) there's no indication of which is default. But as far as I can tell, this PR just fixes the current design, so any redesign can be done later.

If this gets approved I'll update appdata.xml then to avoid conflicts.