### PR TITLE
Show all event menu items

### DIFF
--- a/src/Widgets/EventMenu.vala
+++ b/src/Widgets/EventMenu.vala
@@ -56,6 +56,8 @@ public class Maya.EventMenu : Gtk.Menu {
         edit_item.activate.connect (() => {
             ((Maya.Application) GLib.Application.get_default ()).window.on_modified (comp);
         });
+
+        show_all ();
     }
 
     private void remove_event () {


### PR DESCRIPTION
On Odin, the event context menu was appearing empty.  This fixes it.