### PR TITLE
AgendaEventRow.css: Rely on stylesheet for colors

### DIFF
--- a/data/style/AgendaEventRow.css
+++ b/data/style/AgendaEventRow.css
@@ -1,7 +1,7 @@
 .event {
-    background: alpha(@accent_color, 0.15);
+    background: @selected_bg_color;
     border-radius: 3px;
-    color: shade(@accent_color, 0.65);
+    color: @selected_fg_color;
     padding: 6px;
 }
 


### PR DESCRIPTION
Fixes #612 
Fixes #267 

When combined with https://github.com/elementary/stylesheet/pull/852 relies on the stylesheet to set accent-based foreground and background colors