### PR TITLE
Make EventStore ranges inclusive

### DIFF
--- a/core/Services/Calendar/EventStore.vala
+++ b/core/Services/Calendar/EventStore.vala
@@ -349,18 +349,27 @@ public class Calendar.EventStore : Object {
         return dt;
     }
 
+    /** Set the values of month_range and data_range.
+     *
+     * month_range contains the entire month starting with month_start.
+     *
+     * data_range fills in the rest of the visible calendar block, including the
+     *  week before the month starts and the week after it ends.
+     */
     private void compute_ranges () {
         if (state_settings != null) {
             state_settings.set_string ("month-page", month_start.format ("%Y-%m"));
         }
 
-        var month_end = month_start.add_full (0, 1, -1);
+        var month_end = month_start.add_full (0, 1, 0);
         month_range = new Calendar.Util.DateRange (month_start, month_end);
 
         int dow = month_start.get_day_of_week ();
         int wso = (int) week_starts_on;
         int offset = 0;
 
+        // offset corresponds number of days from the start of the week to 
+        // month_start, as seen on a displayed calendar.
         if (wso < dow) {
             offset = dow - wso;
         } else if (wso > dow) {
@@ -370,18 +379,16 @@ public class Calendar.EventStore : Object {
         var data_range_first = month_start.add_days (-offset);
 
         dow = month_end.get_day_of_week ();
-        wso = (int) (week_starts_on + 6);
-
-        // WSO must be between 1 and 7
-        if (wso > 7)
-            wso = wso - 7;
 
         offset = 0;
-
-        if (wso < dow)
-            offset = 7 + wso - dow;
-        else if (wso > dow)
-            offset = wso - dow;
+        if (wso < dow) {
+            offset = dow - wso;
+        } else if (wso > dow) {
+            offset = 7 + dow - wso;
+        }
+        // The number of days to the end of the week is the same as going to the
+        // start of the week and adding 7.
+        offset = -offset + 7;
 
         var data_range_last = month_end.add_days (offset);
 

--- a/core/Services/Calendar/Util/DateIterator.vala
+++ b/core/Services/Calendar/Util/DateIterator.vala
@@ -68,8 +68,11 @@ public class Calendar.Util.DateIterator : Object, Gee.Traversable<GLib.DateTime>
         return true;
     }
 
+    /** Returns true if the next day after current would fall inside of range, 
+     *  false otherwise.
+     */
     public bool has_next () {
-        return current.compare (range.last_dt) < 0;
+        return current.add_days (1).compare (range.last_dt) < 0;
     }
 
     public new GLib.DateTime get () {

--- a/core/Services/Calendar/Util/DateTime.vala
+++ b/core/Services/Calendar/Util/DateTime.vala
@@ -88,6 +88,10 @@ namespace Calendar.Util {
         return result;
     }
 
+    /** Gets the start of the month that contains the given date
+     *
+     * Returns midnight (00:00) on that date.
+     */
     public GLib.DateTime datetime_get_start_of_month (owned GLib.DateTime? date = null) {
         if (date == null) {
             date = new GLib.DateTime.now_local ();

--- a/core/Tests/eventstore-tests.vala
+++ b/core/Tests/eventstore-tests.vala
@@ -94,10 +94,9 @@ void test_ranges () {
     var setstr = Intl.setlocale (LocaleCategory.TIME, localestr);
     assert_nonnull (setstr);
     assert (setstr == localestr);
-    
+
     var store = new TestStore ();
     store.month_start = new GLib.DateTime.local (2020,11,1,0,0,0);
-    debug (@"$(store.month_range.first_dt) to $(store.month_range.last_dt)");
     var month_start = new GLib.DateTime.local (2020,11,1,12,13,45);
     var month_end = new GLib.DateTime.local (2020,11,30,12,13,45);
     // Test in range
@@ -109,7 +108,6 @@ void test_ranges () {
     assert (month_start.compare (store.month_range.first_dt) < 0);
     assert (month_end.compare (store.month_range.last_dt) > 0);
 
-    debug (@"data: $(store.data_range.first_dt) to $(store.data_range.last_dt)");
     var data_start = new GLib.DateTime.local (2020,10,26,12,13,45);
     var data_end = new GLib.DateTime.local (2020,12,6,12,13,45);
     assert (data_start.compare (store.data_range.first_dt) >= 0);
@@ -136,4 +134,3 @@ int main (string[] args) {
     add_range_tests ();
     return Test.run ();
 }
-

--- a/core/Tests/eventstore-tests.vala
+++ b/core/Tests/eventstore-tests.vala
@@ -88,13 +88,52 @@ void test_week_start () {
     assert (week_start == DateWeekday.SATURDAY);
 }
 
+void test_ranges () {
+    // EventStore.data_range depends on week start, so set en_GB (Monday)
+    var localestr = "en_GB.utf8";
+    var setstr = Intl.setlocale (LocaleCategory.TIME, localestr);
+    assert_nonnull (setstr);
+    assert (setstr == localestr);
+    
+    var store = new TestStore ();
+    store.month_start = new GLib.DateTime.local (2020,11,1,0,0,0);
+    debug (@"$(store.month_range.first_dt) to $(store.month_range.last_dt)");
+    var month_start = new GLib.DateTime.local (2020,11,1,12,13,45);
+    var month_end = new GLib.DateTime.local (2020,11,30,12,13,45);
+    // Test in range
+    assert (month_start.compare (store.month_range.first_dt) >= 0);
+    assert (month_end.compare (store.month_range.last_dt) <= 0);
+    // Test out of range
+    month_start = month_start.add_days (-1);
+    month_end = month_end.add_days (1);
+    assert (month_start.compare (store.month_range.first_dt) < 0);
+    assert (month_end.compare (store.month_range.last_dt) > 0);
+
+    debug (@"data: $(store.data_range.first_dt) to $(store.data_range.last_dt)");
+    var data_start = new GLib.DateTime.local (2020,10,26,12,13,45);
+    var data_end = new GLib.DateTime.local (2020,12,6,12,13,45);
+    assert (data_start.compare (store.data_range.first_dt) >= 0);
+    assert (data_end.compare (store.data_range.last_dt) <= 0);
+    // Test out of range
+    data_start = data_start.add_days (-1);
+    data_end = new GLib.DateTime.local (2020,12,7,0,0,1);
+    assert (data_start.compare (store.data_range.first_dt) < 0);
+    assert (data_end.compare (store.data_range.last_dt) > 0);
+}
+
 void add_locale_tests () {
     Test.add_func ("/EventStore/Locale/nl_langinfo", test_posix_nl_langinfo);
     Test.add_func ("/EventStore/Locale/week_start", test_week_start);
 }
 
+void add_range_tests () {
+    Test.add_func ("/EventStore/Range/ranges", test_ranges);
+}
+
 int main (string[] args) {
     Test.init (ref args);
     add_locale_tests ();
+    add_range_tests ();
     return Test.run ();
 }
+

--- a/core/Tests/util-tests.vala
+++ b/core/Tests/util-tests.vala
@@ -116,6 +116,28 @@ void test_all_day () {
     assert (g_dtend.format ("%FT%T%z") == "2019-11-21T00:00:00-0600");
 }
 
+/*
+ *
+ * Tests for DateRange
+ *
+ */
+
+/** Basic test of DateRange.to_list: does it return only dates within the range?
+ */
+void test_daterange_to_list () {
+    var start_time = new DateTime.local (2019, 11, 20, 0, 0, 0);
+    var end_time = new DateTime.local (2019, 11, 22, 23, 59, 59);
+    var range = new Calendar.Util.DateRange (start_time, end_time);
+    var list = range.to_list ();
+    debug (@"$(list.get (0))");
+    debug (@"$(list.get (list.size-1))");
+    var days_contained = 3;
+    assert (list.size == days_contained);
+    debug (@"$(start_time.compare (list.get (0)))");
+    assert (start_time.compare (list.get (0)) == 0);
+    assert (end_time.compare (list.get (list.size-1).add_days (1)) < 0);
+}
+
 // Test that the is_event_in_range function works with all day events, which are
 // in UTC instead of local time
 void test_daterange_all_day () {
@@ -190,7 +212,10 @@ void add_timezone_tests () {
     Test.add_func ("/Utils/TimeZone/hour_offset", test_hour_offset);
     Test.add_func ("/Utils/TimeZone/half_hour_offset", test_half_hour_offset);
     Test.add_func ("/Utils/TimeZone/45_minute_offset", test_45_minute_offset);
+}
 
+void add_daterange_tests () {
+    Test.add_func ("/Utils/DateRange/to_list", test_daterange_to_list);
     Test.add_func ("/Utils/DateRange/all_day", test_daterange_all_day);
 }
 
@@ -208,6 +233,7 @@ int main (string[] args) {
 
     Test.init (ref args);
     add_timezone_tests ();
+    add_daterange_tests ();
     add_datetime_tests ();
     var result = Test.run ();
 

--- a/core/Tests/util-tests.vala
+++ b/core/Tests/util-tests.vala
@@ -129,13 +129,10 @@ void test_daterange_to_list () {
     var end_time = new DateTime.local (2019, 11, 22, 23, 59, 59);
     var range = new Calendar.Util.DateRange (start_time, end_time);
     var list = range.to_list ();
-    debug (@"$(list.get (0))");
-    debug (@"$(list.get (list.size-1))");
     var days_contained = 3;
     assert (list.size == days_contained);
-    debug (@"$(start_time.compare (list.get (0)))");
     assert (start_time.compare (list.get (0)) == 0);
-    assert (end_time.compare (list.get (list.size-1).add_days (1)) < 0);
+    assert (end_time.compare (list.get (list.size - 1).add_days (1)) < 0);
 }
 
 // Test that the is_event_in_range function works with all day events, which are

--- a/src/Grid/CalendarView.vala
+++ b/src/Grid/CalendarView.vala
@@ -121,8 +121,9 @@ public class Maya.View.CalendarView : Gtk.Grid {
 
     void on_events_added (E.Source source, Gee.Collection<ECal.Component> events) {
         Idle.add ( () => {
-            foreach (var event in events)
+            foreach (var event in events) {
                 add_event (source, event);
+            }
 
             return false;
         });


### PR DESCRIPTION
Fixes #634 

This PR makes it so that events occurring on the last day of the month and grid will properly appear in their respective ranges. I had to make some fixes elsewhere that assumed the old behavior to get this to work. I also added tests for these behaviors.