### PR TITLE
Use libical timezones where possible

### DIFF
--- a/core/Services/Calendar/Util/ICalTime.vala
+++ b/core/Services/Calendar/Util/ICalTime.vala
@@ -88,7 +88,7 @@ namespace Calendar.Util {
      * Converts the given ICal.Time to a DateTime.
      * XXX : Track next versions of evolution in order to convert ICal.Timezone to GLib.TimeZone with a dedicated function…
      */
-    public GLib.DateTime icaltime_to_datetime (ICal.Time date) {
+    public GLib.DateTime icaltime_to_datetime1 (ICal.Time date) {
 #if E_CAL_2_0
         int year, month, day, hour, minute, second;
         date.get_date (out year, out month, out day);
@@ -99,5 +99,31 @@ namespace Calendar.Util {
         return new GLib.DateTime (icaltime_get_timezone (date), date.year, date.month,
             date.day, date.hour, date.minute, date.second);
 #endif
+    }
+
+    /**
+     * Converts the given ICal.Time to a DateTime, represented in the system
+     * timezone.
+     *
+     * All timezone information is lost.
+     */
+    public GLib.DateTime icaltime_to_local_datetime (ICal.Time date) {
+        assert (!date.is_null_time ());
+        var converted = icaltime_convert_to_local (date);
+#if E_CAL_2_0
+        int year, month, day, hour, minute, second;
+        converted.get_date (out year, out month, out day);
+        converted.get_time (out hour, out minute, out second);
+        return new GLib.DateTime.local (year, month,
+            day, hour, minute, second);
+#else
+        return new GLib.DateTime.local (date.year, date.month,
+            date.day, date.hour, date.minute, date.second);
+#endif
+    }
+
+    public ICal.Time icaltime_convert_to_local (ICal.Time time) {
+        var system_tz = Calendar.TimeManager.get_default ().system_timezone;
+        return time.convert_to_zone (system_tz);
     }
 }

--- a/daemon/Daemon.vala
+++ b/daemon/Daemon.vala
@@ -104,7 +104,7 @@ namespace Maya {
 #endif
                         if (trigger.get_kind () == ECal.ComponentAlarmTriggerKind.RELATIVE_START) {
                             ICal.Duration duration = trigger.get_duration ();
-                            var start_time = Calendar.Util.icaltime_to_datetime (comp.get_dtstart ());
+                            var start_time = Calendar.Util.icaltime_to_local_datetime (comp.get_dtstart ());
                             var now = new DateTime.now_local ();
                             if (now.compare (start_time) > 0) {
                                 continue;
@@ -150,7 +150,7 @@ namespace Maya {
 
             unowned ICal.Component comp = event.get_icalcomponent ();
             var primary_text = "%s".printf (comp.get_summary ());
-            var start_time = Calendar.Util.icaltime_to_datetime (comp.get_dtstart ());
+            var start_time = Calendar.Util.icaltime_to_local_datetime (comp.get_dtstart ());
             var now = new DateTime.now_local ();
             string secondary_text = "";
             var h24_settings = new GLib.Settings ("org.gnome.desktop.interface");

--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -180,11 +180,11 @@ public class Maya.View.AgendaView : Gtk.ScrolledWindow {
     private int compare_rows (AgendaEventRow row1, AgendaEventRow row2) {
         unowned ICal.Component ical_event1 = row1.calevent.get_icalcomponent ();
         DateTime start_date1, end_date1;
-        Calendar.Util.icalcomponent_get_local_datetimes (ical_event1, out start_date1, out end_date1);
+        Calendar.Util.icalcomponent_get_local_datetimes_new (ical_event1, out start_date1, out end_date1);
 
         unowned ICal.Component ical_event2 = row2.calevent.get_icalcomponent ();
         DateTime start_date2, end_date2;
-        Calendar.Util.icalcomponent_get_local_datetimes (ical_event2, out start_date2, out end_date2);
+        Calendar.Util.icalcomponent_get_local_datetimes_new (ical_event2, out start_date2, out end_date2);
 
         var comp = start_date1.compare (start_date2);
         if (comp != 0) {

--- a/src/EventEdition/RepeatPanel.vala
+++ b/src/EventEdition/RepeatPanel.vala
@@ -351,7 +351,7 @@ public class Maya.View.EventEdition.RepeatPanel : Gtk.Grid {
                 ends_combobox.active = 0;
             } else {
                 ends_combobox.active = 1;
-                end_datepicker.date = Calendar.Util.icaltime_to_datetime (until);
+                end_datepicker.date = Calendar.Util.icaltime_to_datetime1 (until);
             }
             if (rrule.get_count () > 0) {
                 end_entry.value = rrule.get_count ();
@@ -362,7 +362,7 @@ public class Maya.View.EventEdition.RepeatPanel : Gtk.Grid {
         property = comp.get_first_property (ICal.PropertyKind.EXDATE_PROPERTY);
         while (property != null) {
             var exdate = property.get_exdate ();
-            var exception_grid = new ExceptionGrid (Calendar.Util.icaltime_to_datetime (exdate));
+            var exception_grid = new ExceptionGrid (Calendar.Util.icaltime_to_datetime1 (exdate));
             exception_grid.show_all ();
             exceptions_list.add (exception_grid);
             property = comp.get_next_property (ICal.PropertyKind.EXDATE_PROPERTY);


### PR DESCRIPTION
Fixes #572 (and maybe others?)
Initially discussed in #660 

This is going to be part 1.

I removed all the `GLib.TimeZone` logic that I could and instead used libical functions. This should solve issues with unrecognized timezones, since every event has a timezone that is defined within libical. For example, it will solve #572 because it doesn't need to map the timezone in libical's data to a GLib.TimeZone, which was failing.

As discussed on Slack, I plan to remove as many instances of GLib.DateTime as possible in a future PR in favor of using ICal.Time throughout the codebase. But I think that this is a mostly complete and self-contained change, so to break it up as much as possible I'm submitting it as its own PR.