### PR TITLE
Strip Alpha From Calendar Color if Needed

### DIFF
--- a/src/Grid/EventButton.vala
+++ b/src/Grid/EventButton.vala
@@ -123,7 +123,7 @@ public class Maya.View.EventButton : Gtk.Revealer {
     private void reload_css (string background_color) {
         var provider = new Gtk.CssProvider ();
         try {
-            var colored_css = EVENT_CSS.printf (background_color.length == 9 ? background_color[0:-2] : background_color);
+            var colored_css = EVENT_CSS.printf (background_color.slice (0, 7));
             provider.load_from_data (colored_css, colored_css.length);
 
             grid_style_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);

--- a/src/Grid/EventButton.vala
+++ b/src/Grid/EventButton.vala
@@ -123,7 +123,7 @@ public class Maya.View.EventButton : Gtk.Revealer {
     private void reload_css (string background_color) {
         var provider = new Gtk.CssProvider ();
         try {
-            var colored_css = EVENT_CSS.printf (background_color);
+            var colored_css = EVENT_CSS.printf (background_color.length == 9 ? background_color[0:-2] : background_color);
             provider.load_from_data (colored_css, colored_css.length);
 
             grid_style_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);

--- a/src/Widgets/AgendaEventRow.vala
+++ b/src/Widgets/AgendaEventRow.vala
@@ -365,7 +365,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
     private void reload_css (string background_color) {
         var provider = new Gtk.CssProvider ();
         try {
-            var colored_css = EVENT_CSS.printf (background_color);
+            var colored_css = EVENT_CSS.printf (background_color.length == 9 ? background_color[0:-2] : background_color);
             provider.load_from_data (colored_css, colored_css.length);
 
             event_image_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);

--- a/src/Widgets/AgendaEventRow.vala
+++ b/src/Widgets/AgendaEventRow.vala
@@ -365,7 +365,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
     private void reload_css (string background_color) {
         var provider = new Gtk.CssProvider ();
         try {
-            var colored_css = EVENT_CSS.printf (background_color.length == 9 ? background_color[0:-2] : background_color);
+            var colored_css = EVENT_CSS.printf (background_color.slice (0, 7));
             provider.load_from_data (colored_css, colored_css.length);
 
             event_image_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);

--- a/src/Widgets/SourceRow.vala
+++ b/src/Widgets/SourceRow.vala
@@ -166,7 +166,7 @@ public class Calendar.SourceRow : Gtk.ListBoxRow {
     }
 
     private void style_calendar_color (string color) {
-        var css_color = "@define-color accent_color %s;".printf (color.length == 9 ? color[0:-2] : color);
+        var css_color = "@define-color accent_color %s;".printf (color.slice (0, 7));
 
         var style_provider = new Gtk.CssProvider ();
 

--- a/src/Widgets/SourceRow.vala
+++ b/src/Widgets/SourceRow.vala
@@ -166,7 +166,7 @@ public class Calendar.SourceRow : Gtk.ListBoxRow {
     }
 
     private void style_calendar_color (string color) {
-        var css_color = "@define-color accent_color %s;".printf (color);
+        var css_color = "@define-color accent_color %s;".printf (color.length == 9 ? color[0:-2] : color);
 
         var style_provider = new Gtk.CssProvider ();
 


### PR DESCRIPTION
Gtk.CssProvider fails if when setting `accent_color` to a RGBA value, this PR make sure that we are setting  only the RGB part of the hex color if we recevie a RGBA one.