### PR TITLE
AppData: Use white/Lime 900 for brand banner

### DIFF
--- a/data/io.elementary.calendar.appdata.xml.in
+++ b/data/io.elementary.calendar.appdata.xml.in
@@ -204,8 +204,12 @@
   <url type="translate">https://l10n.elementary.io/projects/calendar</url>
   <update_contact>contact_at_elementary.io</update_contact>
   <screenshots>
-  <screenshot type="default">
-    <image>https://raw.githubusercontent.com/elementary/calendar/master/data/screenshot.png</image>
-  </screenshot>
-</screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/elementary/calendar/master/data/screenshot.png</image>
+    </screenshot>
+  </screenshots>
+  <custom>
+    <value key="x-appcenter-color-primary">#fff</value>
+    <value key="x-appcenter-color-primary-text">#206b00</value>
+  </custom>
 </component>


### PR DESCRIPTION
I played with other combinations and thought this looked the nicest. Any green background felt too heavy and lost the icon too much.

![Screenshot from 2021-08-16 14-20-08](https://user-images.githubusercontent.com/611168/129624816-53b28145-0ef1-451d-af10-ec87bf758756.png)

![Screenshot from 2021-08-16 14-20-05](https://user-images.githubusercontent.com/611168/129624829-d129778b-3c91-42f2-aa82-bd69ea05331f.png)
