### PR TITLE
Revert "utils: Workaround wrong ICal.Time.get_timezone() binding to fix memleak (#719)"

### DIFF
--- a/core/Services/Calendar/Util/ICalTime.vala
+++ b/core/Services/Calendar/Util/ICalTime.vala
@@ -33,57 +33,33 @@ namespace Calendar.Util {
             return new GLib.TimeZone.local ();
         }
 
-        var tzid = date.get_tzid ();
+        unowned string? tzid = date.get_tzid ();
         if (tzid == null) {
             // In libical, null tzid means floating time
             assert (date.get_timezone () == null);
             return new GLib.TimeZone.local ();
         }
 
-        // Otherwise, get timezone from ICal
-        // First, try using the tzid property
-        if (tzid != null) {
-            /* Standard city names are usable directly by GLib, so we can bypass
-             * the ICal scaffolding completely and just return a new
-             * GLib.TimeZone here. This method also preserves all the timezone
-             * information, like going in/out of daylight savings, which parsing
-             * from UTC offset does not.
-             * Note, this can't recover from failure, since GLib.TimeZone
-             * constructor doesn't communicate failure information. This block
-             * will always return a GLib.TimeZone, which will be UTC if parsing
-             * fails for some reason.
-             */
-            var prefix = "/freeassociation.sourceforge.net/";
-            if (tzid.has_prefix (prefix)) {
-                // TZID has prefix "/freeassociation.sourceforge.net/",
-                // indicating a libical TZID.
-                return new GLib.TimeZone (tzid.offset (prefix.length));
-            } else {
-                // TZID does not have libical prefix, potentially indicating an Olson
-                // standard city name.
-                return new GLib.TimeZone (tzid);
-            }
+        /* Standard city names are usable directly by GLib, so we can bypass
+         * the ICal scaffolding completely and just return a new
+         * GLib.TimeZone here. This method also preserves all the timezone
+         * information, like going in/out of daylight savings, which parsing
+         * from UTC offset does not.
+         * Note, this can't recover from failure, since GLib.TimeZone
+         * constructor doesn't communicate failure information. This block
+         * will always return a GLib.TimeZone, which will be UTC if parsing
+         * fails for some reason.
+         */
+        const string LIBICAL_TZ_PREFIX = "/freeassociation.sourceforge.net/";
+        if (tzid.has_prefix (LIBICAL_TZ_PREFIX)) {
+            // TZID has prefix "/freeassociation.sourceforge.net/",
+            // indicating a libical TZID.
+            return new GLib.TimeZone (tzid.offset (LIBICAL_TZ_PREFIX.length));
+        } else {
+            // TZID does not have libical prefix, potentially indicating an Olson
+            // standard city name.
+            return new GLib.TimeZone (tzid);
         }
-        // If tzid fails, try ICal.Time.get_timezone ()
-        unowned ICal.Timezone? timezone = null;
-        if (timezone == null && date.get_timezone () != null) {
-            timezone = date.get_timezone ();
-        }
-        // If timezone is still null), it's floating: set to local time
-        if (timezone == null) {
-            return new GLib.TimeZone.local ();
-        }
-
-        // Get UTC offset and format for GLib.TimeZone constructor
-        int is_daylight;
-        int interval = timezone.get_utc_offset (date, out is_daylight);
-        bool is_positive = interval >= 0;
-        interval = interval.abs ();
-        var hours = (interval / 3600);
-        var minutes = (interval % 3600) / 60;
-        var hour_string = "%s%02d:%02d".printf (is_positive ? "+" : "-", hours, minutes);
-
-        return new GLib.TimeZone (hour_string);
     }
 
     /**

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -196,6 +196,8 @@ namespace Maya {
         GtkClutter.init (ref args);
         var app = new Application ();
 
-        return app.run (args);
+        int res = app.run (args);
+        ICal.Object.free_global_objects ();
+        return res;
     }
 }


### PR DESCRIPTION
Also add code to release the internal cache at the end of the program