### PR TITLE
Granite.HyperTextView: Support for clickable hyperlinks in event description

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You'll need the following dependencies:
 * libgeocode-glib-dev
 * libgeoclue-2-dev
 * libglib2.0-dev
-* libgranite-dev >= 6.0.0
+* libgranite-dev >= 6.2.0
 * libgtk-3-dev
 * libical-dev
 * libhandy-1-dev >= 0.90.0

--- a/data/io.elementary.calendar.appdata.xml.in
+++ b/data/io.elementary.calendar.appdata.xml.in
@@ -11,6 +11,14 @@
     <p>A slim, lightweight calendar app that syncs and manages multiple calendars in one place, like Google Calendar, Outlook and CalDAV.</p>
   </description>
   <releases>
+    <release version="6.1.0" date="2021-12-02" urgency="medium">
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>Follow email and web links in the event description with Control + Click</li>
+        </ul>
+      </description>
+    </release>
     <release version="6.0.3" date="2021-10-26" urgency="medium">
       <description>
         <p>Fixes:</p>

--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,7 @@ pkgconfig = import('pkgconfig')
 
 glib_dep = dependency('glib-2.0')
 gee_dep = dependency('gee-0.8')
-granite_dep = dependency('granite', version: '>=6.0.0')
+granite_dep = dependency('granite', version: '>=6.2.0')
 gtk_dep = dependency('gtk+-3.0', version: '>=3.22')
 handy_dep = dependency('libhandy-1', version: '>=0.90.0')
 libedataserver_dep = dependency('libedataserver-1.2', version: '>=3.8.0')

--- a/src/EventEdition/InfoPanel.vala
+++ b/src/EventEdition/InfoPanel.vala
@@ -20,7 +20,7 @@
 
 public class Maya.View.EventEdition.InfoPanel : Gtk.Grid {
     private Gtk.Entry title_entry;
-    private Gtk.TextView comment_textview;
+    private Granite.HyperTextView comment_textview;
     private Granite.Widgets.DatePicker from_date_picker;
     private Granite.Widgets.DatePicker to_date_picker;
     private Gtk.Switch allday_switch;
@@ -143,7 +143,7 @@ public class Maya.View.EventEdition.InfoPanel : Gtk.Grid {
         }
 
         var comment_label = new Granite.HeaderLabel (_("Comments:"));
-        comment_textview = new Gtk.TextView ();
+        comment_textview = new Granite.HyperTextView ();
         comment_textview.set_wrap_mode (Gtk.WrapMode.WORD_CHAR);
         comment_textview.accepts_tab = false;
         comment_textview.set_border_window_size (Gtk.TextWindowType.LEFT, 2);


### PR DESCRIPTION
Uses `Granite.HyperTextView` for the comment textview of an event. This allows to Ctrl + Click on an existing hyperlink in the event description.

Makes https://github.com/elementary/calendar/pull/692 obsolete.