### PR TITLE
Make default calendar checkbox insensitive if read-only

### DIFF
--- a/src/SourceDialog/SourceDialog.vala
+++ b/src/SourceDialog/SourceDialog.vala
@@ -270,8 +270,9 @@ public class Maya.View.SourceDialog : Gtk.Grid {
             try {
                 var registry = new E.SourceRegistry.sync (null);
                 var source_is_default = source.equal (registry.default_calendar);
+                var source_is_readonly = Calendar.EventStore.get_default ().calclient_is_readonly (source);
                 // Prevent source from being "unset" as default, which is undefined
-                is_default_check.sensitive = !source_is_default;
+                is_default_check.sensitive = !(source_is_default || source_is_readonly);
                 is_default_check.active = source_is_default;
             } catch (GLib.Error error) {
                 critical (error.message);


### PR DESCRIPTION
Fixes an issue reported in #553. Previously we didn't check whether a calendar is read-only, so you could set it as default, with some strange results. This fixes that by disabling the checkbox.

Since a disabled checkbox can now mean multiple things (read-only calendar if unchecked, or already default if checked), should we add a label explaining why it's disabled? I'm not sure if that's necessary, but it could be helpful.