### PR TITLE
Update sources in calendar chooser when source connects

### DIFF
--- a/src/EventEdition/InfoPanel.vala
+++ b/src/EventEdition/InfoPanel.vala
@@ -163,7 +163,7 @@ public class Maya.View.EventEdition.InfoPanel : Gtk.Grid {
         // Row: title & calendar
         attach (title_label, 0, 0, 1, 1);
         attach (title_entry, 0, 1, 1, 1);
-        if (calendar_button.sources.length () > 1 && parent_dialog.can_edit) {
+        if (parent_dialog.can_edit) {
             attach (calendar_label, 1, 0, 4, 1);
             attach (calendar_button, 1, 1, 4, 1);
         }

--- a/src/Widgets/CalendarButton.vala
+++ b/src/Widgets/CalendarButton.vala
@@ -45,6 +45,7 @@ public class Maya.View.Widgets.CalendarButton : Gtk.MenuButton {
 
         var button_grid = new Gtk.Grid ();
         button_grid.column_spacing = 6;
+        button_grid.valign = Gtk.Align.CENTER;
         button_grid.add (current_calendar_grid);
         button_grid.add (new Gtk.Image.from_icon_name ("pan-down-symbolic", Gtk.IconSize.MENU));
         add (button_grid);


### PR DESCRIPTION
If calendar chooser is displayed before sources are fully loaded, re-renders sources so that all calendars become available.

This PR blocks [insert PR] (Add button for adding event) as without it the added functionality is largely useless. The implementation of the linked PR relies on the existing method of launching the calendar application with a flag (`--add-event`) that tells the application to open a new event dialog. However, as currently implemented the new event dialog is loaded prior to all event sources having been initialized, so it is impossible to choose a destination calendar for the new event.

This PR addresses this issue by 1) displaying the calendar selection regardless of the number of calendar sources the user has and 2) re-rendering the calendar options when sources are updated.

While a DBus implementation for adding new events from wingpanel would be a better option (and one I will explore in future,) this change does at least make the aforementioned flag usable.