### PR TITLE
Add check for termination of by_day_array

### DIFF
--- a/src/EventEdition/RepeatPanel.vala
+++ b/src/EventEdition/RepeatPanel.vala
@@ -273,7 +273,11 @@ public class Maya.View.EventEdition.RepeatPanel : Gtk.Grid {
     private void load_weekly_recurrence (ICal.Recurrence rrule) {
         repeat_combobox.active = 1;
         var by_day = rrule.get_by_day_array ();
-        for (uint i = 0; i < by_day.length; i++) {
+        for (
+            uint i = 0;
+            i < by_day.length && (by_day.index (i) != ICal.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX);
+            i++
+        ) {
             switch (ICal.Recurrence.day_day_of_week (by_day.index (i))) {
                 case ICal.RecurrenceWeekday.SUNDAY_WEEKDAY:
                     sun_button.active = true;


### PR DESCRIPTION
Fixes #759 

Description of the reasoning there. The array has a special terminator value, which I added a check for. If it's encountered, stop looping over the array, since further entries are no longer valid.