### PR TITLE
Fix meson warning for run_command

### DIFF
--- a/core/Tests/meson.build
+++ b/core/Tests/meson.build
@@ -19,7 +19,7 @@ util_tests = executable(
 test('Utils Tests', util_tests, suite: 'core', is_parallel: false)
 
 # We need these three locales to run the tests
-locales = run_command('locale', '-a').stdout().split('\n')
+locales = run_command('locale', '-a', check: false).stdout().split('\n')
 if locales.contains ('en_GB.utf8') and locales.contains ('en_US.utf8') and locales.contains ('ar_AE.utf8')
     eventstore_tests = executable(
       tests_name + '-eventstore',

--- a/core/Tests/meson.build
+++ b/core/Tests/meson.build
@@ -19,7 +19,7 @@ util_tests = executable(
 test('Utils Tests', util_tests, suite: 'core', is_parallel: false)
 
 # We need these three locales to run the tests
-locales = run_command('locale', '-a', check: false).stdout().split('\n')
+locales = run_command('locale', '-a', check: true).stdout().split('\n')
 if locales.contains ('en_GB.utf8') and locales.contains ('en_US.utf8') and locales.contains ('ar_AE.utf8')
     eventstore_tests = executable(
       tests_name + '-eventstore',


### PR DESCRIPTION
Since I am already fixing the other repos with this issue, I thought I might do it here aswell.

TLDR: meson will change the default behaviour of `run_command` and displays that as a warning when building.
See: https://github.com/mesonbuild/meson/issues/9300

![image](https://user-images.githubusercontent.com/10424668/193398817-a387b1cf-6b26-410f-8e6e-47dbfe25343d.png)
