### PR TITLE
Fix day in month in Grid with GLib 2.73.1+

### DIFF
--- a/src/Grid/GridDay.vala
+++ b/src/Grid/GridDay.vala
@@ -101,8 +101,10 @@ public class Maya.View.GridDay : Gtk.EventBox {
         Gtk.TargetEntry dnd = {"binary/calendar", 0, 0};
         Gtk.drag_dest_set (this, Gtk.DestDefaults.MOTION, {dnd}, Gdk.DragAction.MOVE);
 
-        this.notify["date"].connect (() => {
-            label.label = date.get_day_of_month ().to_string ();
+        this.bind_property ("date", label, "label", BindingFlags.SYNC_CREATE, (binding, srcval, ref targetval) => {
+            unowned var date = (GLib.DateTime) srcval.get_boxed ();
+            targetval.take_string (date.get_day_of_month ().to_string ());
+            return true;
         });
     }
 


### PR DESCRIPTION
GLib 2.73.1 [no longer fires notify signal for properties set during instantiation](https://gitlab.gnome.org/GNOME/glib/-/commit/8851112b8de024ff6fb4235a4475ffa6c98973dc). This resulted in the label remaining empty. Now, the `Grid.update_day` would also run and set `date` property but that did not have an effect – probably because the date did not change.

We need to set the initial label ourselves. To avoid code duplication, we can just use `GBinding`.

Fixes: https://github.com/elementary/calendar/issues/761

cc @bobby285271
