### PR TITLE
Meson option to build without libchamplain

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -38,7 +38,7 @@ else
     libsoup_dep = dependency('libsoup-2.4')
 endif
 gmodule_dep = dependency('gmodule-2.0')
-if get_option('packagekit_backend')
+if get_option('use_libchamplain')
     champlain_dep = dependency('champlain-0.12')
     champlain_gtk_dep = dependency('champlain-gtk-0.12')
     add_project_arguments('--define', 'USE_LIBCHAMPLAIN', language: 'vala')

--- a/meson.build
+++ b/meson.build
@@ -38,8 +38,11 @@ else
     libsoup_dep = dependency('libsoup-2.4')
 endif
 gmodule_dep = dependency('gmodule-2.0')
-champlain_dep = dependency('champlain-0.12')
-champlain_gtk_dep = dependency('champlain-gtk-0.12')
+if get_option('packagekit_backend')
+    champlain_dep = dependency('champlain-0.12')
+    champlain_gtk_dep = dependency('champlain-gtk-0.12')
+    add_project_arguments('--define', 'USE_LIBCHAMPLAIN', language: 'vala')
+endif
 clutter_dep = dependency('clutter-1.0')
 clutter_gtk_dep = dependency('clutter-gtk-1.0')
 folks_dep = dependency('folks')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('use_libchamplain', type : 'boolean', value : true, description : 'Use libchamplain')

--- a/src/EventEdition/EventDialog.vala
+++ b/src/EventEdition/EventDialog.vala
@@ -42,7 +42,7 @@ public class EventDialog : Granite.Dialog {
 
         private EventEdition.GuestsPanel guests_panel;
         private EventEdition.InfoPanel info_panel;
-#ifdef USE_LIBCHAMPLAIN
+#if USE_LIBCHAMPLAIN
         private EventEdition.LocationPanel location_panel;
 #endif        
         private EventEdition.ReminderPanel reminder_panel;
@@ -76,7 +76,7 @@ public class EventDialog : Granite.Dialog {
 
             guests_panel = new EventEdition.GuestsPanel (this);
             info_panel = new EventEdition.InfoPanel (this);
-#ifdef USE_LIBCHAMPLAIN
+#if USE_LIBCHAMPLAIN
             location_panel = new EventEdition.LocationPanel (this);
 #endif
             reminder_panel = new EventEdition.ReminderPanel (this);
@@ -109,7 +109,7 @@ public class EventDialog : Granite.Dialog {
 
                         guests_panel.guests += ev.participants;
 
-#ifdef USE_LIBCHAMPLAIN
+#if USE_LIBCHAMPLAIN
                         if (ev.location.length > 0) {
                             location_panel.location = ev.location;
                         }
@@ -124,7 +124,7 @@ public class EventDialog : Granite.Dialog {
 
             var stack = new Gtk.Stack ();
             stack.add_titled (info_panel, "infopanel", _("General Informations"));
-#ifdef USE_LIBCHAMPLAIN
+#if USE_LIBCHAMPLAIN
             stack.add_titled (location_panel, "locationpanel", _("Location"));
 #endif
             stack.add_titled (guests_panel, "guestspanel", _("Guests"));
@@ -132,7 +132,7 @@ public class EventDialog : Granite.Dialog {
             ///Translators: The name of the repeat panel tab
             stack.add_titled (repeat_panel, "repeatpanel", C_("Section Header", "Repeat")); //vala-lint=space-before-paren
             stack.child_set_property (info_panel, "icon-name", "office-calendar-symbolic");
-#ifdef USE_LIBCHAMPLAIN
+#if USE_LIBCHAMPLAIN
             stack.child_set_property (location_panel, "icon-name", "mark-location-symbolic");
 #endif
             stack.child_set_property (guests_panel, "icon-name", "system-users-symbolic");
@@ -199,7 +199,7 @@ public class EventDialog : Granite.Dialog {
 
         private void save_dialog () {
             info_panel.save ();
-#ifdef USE_LIBCHAMPLAIN
+#if USE_LIBCHAMPLAIN
             location_panel.save ();
 #endif
             guests_panel.save ();

--- a/src/EventEdition/EventDialog.vala
+++ b/src/EventEdition/EventDialog.vala
@@ -44,7 +44,7 @@ public class EventDialog : Granite.Dialog {
         private EventEdition.InfoPanel info_panel;
 #if USE_LIBCHAMPLAIN
         private EventEdition.LocationPanel location_panel;
-#endif        
+#endif
         private EventEdition.ReminderPanel reminder_panel;
         private EventEdition.RepeatPanel repeat_panel;
 

--- a/src/EventEdition/EventDialog.vala
+++ b/src/EventEdition/EventDialog.vala
@@ -42,7 +42,9 @@ public class EventDialog : Granite.Dialog {
 
         private EventEdition.GuestsPanel guests_panel;
         private EventEdition.InfoPanel info_panel;
+#ifdef USE_LIBCHAMPLAIN
         private EventEdition.LocationPanel location_panel;
+#endif        
         private EventEdition.ReminderPanel reminder_panel;
         private EventEdition.RepeatPanel repeat_panel;
 
@@ -74,7 +76,9 @@ public class EventDialog : Granite.Dialog {
 
             guests_panel = new EventEdition.GuestsPanel (this);
             info_panel = new EventEdition.InfoPanel (this);
+#ifdef USE_LIBCHAMPLAIN
             location_panel = new EventEdition.LocationPanel (this);
+#endif
             reminder_panel = new EventEdition.ReminderPanel (this);
             repeat_panel = new EventEdition.RepeatPanel (this);
 
@@ -105,9 +109,11 @@ public class EventDialog : Granite.Dialog {
 
                         guests_panel.guests += ev.participants;
 
+#ifdef USE_LIBCHAMPLAIN
                         if (ev.location.length > 0) {
                             location_panel.location = ev.location;
                         }
+#endif
 
                         event_parsed = true;
                     }
@@ -118,13 +124,17 @@ public class EventDialog : Granite.Dialog {
 
             var stack = new Gtk.Stack ();
             stack.add_titled (info_panel, "infopanel", _("General Informations"));
+#ifdef USE_LIBCHAMPLAIN
             stack.add_titled (location_panel, "locationpanel", _("Location"));
+#endif
             stack.add_titled (guests_panel, "guestspanel", _("Guests"));
             stack.add_titled (reminder_panel, "reminderpanel", _("Reminders"));
             ///Translators: The name of the repeat panel tab
             stack.add_titled (repeat_panel, "repeatpanel", C_("Section Header", "Repeat")); //vala-lint=space-before-paren
             stack.child_set_property (info_panel, "icon-name", "office-calendar-symbolic");
+#ifdef USE_LIBCHAMPLAIN
             stack.child_set_property (location_panel, "icon-name", "mark-location-symbolic");
+#endif
             stack.child_set_property (guests_panel, "icon-name", "system-users-symbolic");
             stack.child_set_property (reminder_panel, "icon-name", "alarm-symbolic");
             stack.child_set_property (repeat_panel, "icon-name", "media-playlist-repeat-symbolic");
@@ -189,7 +199,9 @@ public class EventDialog : Granite.Dialog {
 
         private void save_dialog () {
             info_panel.save ();
+#ifdef USE_LIBCHAMPLAIN
             location_panel.save ();
+#endif
             guests_panel.save ();
             reminder_panel.save ();
             repeat_panel.save ();

--- a/src/meson.build
+++ b/src/meson.build
@@ -61,7 +61,7 @@ calendar_deps = [
     gclue_dep
 ]
 
-if get_option('packagekit_backend')
+if get_option('use_libchamplain')
     calendar_files += files('EventEdition/LocationPanel.vala')
 
     calendar_deps += [

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,7 +10,6 @@ calendar_files = files(
     'EventEdition/GuestGrid.vala',
     'EventEdition/GuestsPanel.vala',
     'EventEdition/InfoPanel.vala',
-    'EventEdition/LocationPanel.vala',
     'EventEdition/ReminderPanel.vala',
     'EventEdition/RepeatPanel.vala',
     'EventParser/EventParser.vala',
@@ -55,14 +54,21 @@ calendar_deps = [
     libsoup_dep,
     gmodule_dep,
     m_dep,
-    champlain_dep,
-    champlain_gtk_dep,
     clutter_dep,
     clutter_gtk_dep,
     folks_dep,
     geocode_glib_dep,
     gclue_dep
 ]
+
+if get_option('packagekit_backend')
+    calendar_files += files('EventEdition/LocationPanel.vala')
+
+    calendar_deps += [
+        champlain_dep,
+        champlain_gtk_dep,
+    ]
+endif
 
 executable(
     meson.project_name(),


### PR DESCRIPTION
Using `libsoup2` and `libsoup3` in the same process is not supported. On distributions with more recent dependencies, `libchamplain` still uses `libsoup2` as dependency. Therefore, Calendar crashes immediately after startup.

```sh
$ io.elementary.calendar 

(process:1855): libsoup-ERROR **: 06:31:48.760: libsoup2 symbols detected. Using libsoup2 and libsoup3 in the same process is not supported.
Trace/breakpoint trap (core dumped)
```

This PR adds a flag to disable libchamplain as a dependency. Tested on Fedora Rawhide.

## With `libchamplain` 

![Bildschirmfoto von 2023-05-25 06 36 00](https://github.com/elementary/calendar/assets/10796736/0b74fd76-2eaf-4773-a9c3-b3d4047cccd3)

## Without `libchamplain`

![Screenshot from 2023-05-25 06 37 01](https://github.com/elementary/calendar/assets/10796736/5e12ab39-c23d-4276-893c-23336a3d4fd0)

@tintou has provided a patch for libchamplain [that allows to use libchamplain with libsoup3 libraries and applications](https://gitlab.gnome.org/GNOME/libchamplain/-/merge_requests/13). If a distribution cannot use this patch, we can provide an alternative with this PR.