### PR TITLE
Rearrange headerbar items

### DIFF
--- a/src/AgendaView.vala
+++ b/src/AgendaView.vala
@@ -31,39 +31,35 @@ public class Maya.View.AgendaView : Gtk.Box {
     private DateTime selected_date;
 
     construct {
-        var contractor = new Maya.View.Widgets.ContractorButtonWithMenu (_("Export or Share the default Calendar"));
+        var application_instance = ((Gtk.Application) GLib.Application.get_default ());
 
-        var source_popover = new Calendar.Widgets.SourcePopover ();
-
-        var menu_button = new Gtk.MenuButton () {
-            image = new Gtk.Image.from_icon_name ("open-menu", Gtk.IconSize.LARGE_TOOLBAR),
-            popover = source_popover,
-            tooltip_text = _("Manage Calendars")
+        var button_add = new Gtk.Button.from_icon_name ("appointment-new", Gtk.IconSize.LARGE_TOOLBAR) {
+            action_name = Maya.MainWindow.ACTION_PREFIX + Maya.MainWindow.ACTION_NEW_EVENT
         };
+        button_add.tooltip_markup = Granite.markup_accel_tooltip (
+            application_instance.get_accels_for_action (button_add.action_name),
+            _("Create a new event")
+        );
+
+        weekday_label = new Gtk.Label ("") {
+            margin_start = 6,
+            xalign = 0
+        };
+        weekday_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
 
         header_bar = new Hdy.HeaderBar () {
             show_close_button = true
         };
-        header_bar.pack_start (contractor);
-        header_bar.pack_end (menu_button);
+        header_bar.pack_start (weekday_label);
+        header_bar.pack_end (button_add);
         header_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
-        weekday_label = new Gtk.Label ("");
-        weekday_label.xalign = 0;
-        weekday_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
-
-        day_label = new Gtk.Label ("");
-        day_label.xalign = 0;
+        day_label = new Gtk.Label ("") {
+            margin_start = 12,
+            margin_end = 12,
+            xalign = 0
+        };
         day_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
-
-        var selected_data_grid = new Gtk.Grid ();
-        selected_data_grid.margin = 6;
-        selected_data_grid.margin_start = selected_data_grid.margin_end = 12;
-        selected_data_grid.hexpand = true;
-        selected_data_grid.row_spacing = 3;
-        selected_data_grid.orientation = Gtk.Orientation.VERTICAL;
-        selected_data_grid.add (weekday_label);
-        selected_data_grid.add (day_label);
 
         var placeholder_label = new Gtk.Label (_("Your upcoming events will be displayed here when you select a date with events."));
         placeholder_label.wrap = true;
@@ -117,7 +113,7 @@ public class Maya.View.AgendaView : Gtk.Box {
 
         var grid = new Gtk.Grid ();
         grid.orientation = Gtk.Orientation.VERTICAL;
-        grid.add (selected_data_grid);
+        grid.add (day_label);
         grid.add (selected_date_events_list);
         grid.add (upcoming_events_list);
 

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -46,14 +46,6 @@ public class Calendar.Widgets.HeaderBar : Hdy.HeaderBar {
             valign = Gtk.Align.CENTER
         };
 
-        var button_add = new Gtk.Button.from_icon_name ("appointment-new", Gtk.IconSize.LARGE_TOOLBAR) {
-            action_name = Maya.MainWindow.ACTION_PREFIX + Maya.MainWindow.ACTION_NEW_EVENT
-        };
-        button_add.tooltip_markup = Granite.markup_accel_tooltip (
-            application_instance.get_accels_for_action (button_add.action_name),
-            _("Create a new event")
-        );
-
         var calmodel = Calendar.EventStore.get_default ();
         set_switcher_date (calmodel.month_start);
 
@@ -65,8 +57,19 @@ public class Calendar.Widgets.HeaderBar : Hdy.HeaderBar {
 
         var spinner = new Maya.View.Widgets.DynamicSpinner ();
 
+        var contractor = new Maya.View.Widgets.ContractorButtonWithMenu (_("Export or Share the default Calendar"));
+
+        var source_popover = new Calendar.Widgets.SourcePopover ();
+
+        var menu_button = new Gtk.MenuButton () {
+            image = new Gtk.Image.from_icon_name ("open-menu", Gtk.IconSize.LARGE_TOOLBAR),
+            popover = source_popover,
+            tooltip_text = _("Manage Calendars")
+        };
+
         pack_start (spinner);
-        pack_end (button_add);
+        pack_end (menu_button);
+        pack_end (contractor);
         set_custom_title (title_grid);
         get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 


### PR DESCRIPTION
Re-arranges some header items so that they are more closely associated with the pane they directly act on:

* The calendar settings and export buttons move to the calendar pane since the export button acts on the default calendar, not the currently visible agenda items, and the settings popover affects which calendars are shown in the calendar view
* The create new event button is now in the agenda pane since the event will be created for the selected day as labeled in this pane
* The agenda pane's label moves up into the header to make more room for events

## BEFORE
![Screenshot from 2023-11-10 11 15 42](https://github.com/elementary/calendar/assets/7277719/a9fa113b-1ee8-49fa-af09-65ca1858548f)

## AFTER
![Screenshot from 2023-11-10 11 21 26](https://github.com/elementary/calendar/assets/7277719/bfedd74a-17d2-44de-af2c-008b17708d35)
