### PR TITLE
Flatpak: Use libportal from Platform

### DIFF
--- a/io.elementary.calendar.yml
+++ b/io.elementary.calendar.yml
@@ -161,17 +161,6 @@ modules:
         url: https://download.gnome.org/sources/geocode-glib/3.26/geocode-glib-3.26.4.tar.xz
         sha256: 2d9a6826d158470449a173871221596da0f83ebdcff98b90c7049089056a37aa
 
-  - name: libportal
-    buildsystem: meson
-    config-opts:
-      - "-Dbackends=['gtk3']"
-      - '-Ddocs=false'
-      - '-Dtests=false'
-    sources:
-      - type: git
-        url: https://github.com/flatpak/libportal.git
-        tag: '0.6'
-
   - name: calendar
     buildsystem: meson
     sources:


### PR DESCRIPTION
libportal is bundled from Platform 8 so we shouldn't need it here anymore