### PR TITLE
EventMenu: Gtk4 Prep

### DIFF
--- a/src/Grid/EventButton.vala
+++ b/src/Grid/EventButton.vala
@@ -53,6 +53,9 @@ public class Maya.View.EventButton : Gtk.Revealer {
 
         add (event_box);
 
+        var context_menu = Maya.EventMenu.build (comp);
+        context_menu.attach_to_widget (this, null);
+
         click_gesture = new Gtk.GestureMultiPress (this) {
             button = 0
         };
@@ -68,10 +71,7 @@ public class Maya.View.EventButton : Gtk.Revealer {
             }
 
             if (event.triggers_context_menu ()) {
-                var menu = new Maya.EventMenu (comp);
-                menu.attach_to_widget (this, null);
-
-                menu.popup_at_pointer (event);
+                context_menu.popup_at_pointer (event);
 
                 click_gesture.set_state (CLAIMED);
                 click_gesture.reset ();
@@ -85,10 +85,7 @@ public class Maya.View.EventButton : Gtk.Revealer {
             var sequence = long_press_gesture.get_current_sequence ();
             var event = long_press_gesture.get_last_event (sequence);
 
-            var menu = new Maya.EventMenu (comp);
-            menu.attach_to_widget (this, null);
-
-            menu.popup_at_pointer (event);
+            context_menu.popup_at_pointer (event);
 
             long_press_gesture.set_state (CLAIMED);
             long_press_gesture.reset ();

--- a/src/Widgets/AgendaEventRow.vala
+++ b/src/Widgets/AgendaEventRow.vala
@@ -238,6 +238,9 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
 
         child = revealer;
 
+        var context_menu = Maya.EventMenu.build (calevent);
+        context_menu.attach_to_widget (this, null);
+
         var cal = (E.SourceCalendar)source.get_extension (E.SOURCE_EXTENSION_CALENDAR);
 
         reload_css (cal.dup_color ());
@@ -266,10 +269,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
             var event = click_gesture.get_last_event (sequence);
 
             if (event.triggers_context_menu ()) {
-                var menu = new Maya.EventMenu (calevent);
-                menu.attach_to_widget (this, null);
-
-                menu.popup_at_pointer (event);
+                context_menu.popup_at_pointer (event);
 
                 click_gesture.set_state (CLAIMED);
                 click_gesture.reset ();
@@ -283,10 +283,7 @@ public class Maya.View.AgendaEventRow : Gtk.ListBoxRow {
             var sequence = long_press_gesture.get_current_sequence ();
             var event = long_press_gesture.get_last_event (sequence);
 
-            var menu = new Maya.EventMenu (calevent);
-            menu.attach_to_widget (this, null);
-
-            menu.popup_at_pointer (event);
+            context_menu.popup_at_pointer (event);
 
             long_press_gesture.set_state (CLAIMED);
             long_press_gesture.reset ();

--- a/src/Widgets/EventMenu.vala
+++ b/src/Widgets/EventMenu.vala
@@ -1,41 +1,28 @@
 /*
  * SPDX-License-Identifier: GPL-3.0-or-later
- * SPDX-FileCopyrightText: 2011-2025 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2011-2026 elementary, Inc. (https://elementary.io)
  *
  * Authored by: Maxwell Barvian
  *              Corentin Noël <corentin@elementaryos.org>
  */
 
-public class Maya.EventMenu : Gtk.Menu {
-    public ECal.Component comp { get; construct set; }
-
-    public EventMenu (ECal.Component comp) {
-        Object (comp: comp);
-    }
-
-    construct {
-        E.Source src = comp.get_data ("source");
-        bool sensitive = src.writable == true && Calendar.EventStore.get_default ().calclient_is_readonly (src) == false;
-
+namespace Maya.EventMenu {
+    public static Gtk.Menu build (ECal.Component comp) {
         var action_edit = new GLib.SimpleAction ("edit", null);
-        action_edit.set_enabled (sensitive);
         action_edit.activate.connect (() => {
             ((Maya.Application) GLib.Application.get_default ()).window.on_modified (comp);
         });
 
         var action_duplicate = new GLib.SimpleAction ("duplicate", null);
-        action_duplicate.set_enabled (sensitive);
         action_duplicate.activate.connect (() => {
             ((Maya.Application) GLib.Application.get_default ()).window.on_duplicated (comp);
         });
 
         var action_remove = new GLib.SimpleAction ("remove", null);
-        action_remove.set_enabled (sensitive);
-        action_remove.activate.connect (remove_event);
+        action_remove.activate.connect (() => remove_event (comp));
 
         var action_add_exception = new GLib.SimpleAction ("add-exception", null);
-        action_add_exception.set_enabled (sensitive);
-        action_add_exception.activate.connect (add_exception);
+        action_add_exception.activate.connect (() => add_exception (comp));
 
         var action_group = new SimpleActionGroup ();
         action_group.add_action (action_edit);
@@ -43,14 +30,9 @@ public class Maya.EventMenu : Gtk.Menu {
         action_group.add_action (action_remove);
         action_group.add_action (action_add_exception);
 
-        insert_action_group ("event", action_group);
-
         var menu_model = new GLib.Menu ();
         menu_model.append (_("Edit…"), "event.edit");
         menu_model.append (_("Duplicate…"), "event.duplicate");
-
-        bind_model (menu_model, null, false);
-        show_all ();
 
         if (comp.has_recurrences ()) {
             menu_model.prepend (_("Remove Event"), "event.remove");
@@ -58,9 +40,24 @@ public class Maya.EventMenu : Gtk.Menu {
         } else {
             menu_model.prepend (_("Remove"), "event.remove");
         }
+
+        var menu = new Gtk.Menu.from_model (menu_model);
+        menu.insert_action_group ("event", action_group);
+
+        E.Source src = comp.get_data ("source");
+        menu.popped_up.connect (() => {
+            var sensitive = src.writable && !Calendar.EventStore.get_default ().calclient_is_readonly (src);
+
+            action_edit.set_enabled (sensitive);
+            action_duplicate.set_enabled (sensitive);
+            action_remove.set_enabled (sensitive);
+            action_add_exception.set_enabled (sensitive);
+        });
+
+        return menu;
     }
 
-    private void remove_event () {
+    private static void remove_event (ECal.Component comp) {
         var application = (Gtk.Application) GLib.Application.get_default ();
         var source = comp.get_data<E.Source> ("source");
         var delete_dialog = new Calendar.DeleteEventDialog (source, comp, ECal.ObjModType.ALL) {
@@ -69,7 +66,7 @@ public class Maya.EventMenu : Gtk.Menu {
         delete_dialog.run_dialog ();
     }
 
-    private void add_exception () {
+    private static void add_exception (ECal.Component comp) {
         var application = (Gtk.Application) GLib.Application.get_default ();
         var source = comp.get_data<E.Source> ("source");
         var delete_dialog = new Calendar.DeleteEventDialog (source, comp, ECal.ObjModType.THIS) {


### PR DESCRIPTION
Can be rebase merged

* Use GLib.Menu instead of Gtk.MenuItem
* PopoverMenu is sealed in GTK4, so make this a namespace with a static func to return a menu. 
* While we're here, set item sensitivity when the menu is shown, not when it's constructed. This way we can cache a copy of the menu and don't have to construct a new one every time