### PR TITLE
VAutoHider: keep a list of children

### DIFF
--- a/src/Grid/VAutoHider.vala
+++ b/src/Grid/VAutoHider.vala
@@ -7,10 +7,13 @@
  */
 
 public class Maya.View.VAutoHider : Gtk.Bin {
+    private List<unowned Gtk.Widget> children;
     private Gtk.Label more_label;
     private Gtk.Box main_box;
 
     construct {
+        children = new List<unowned Gtk.Widget> ();
+
         more_label = new Gtk.Label ("") {
             valign = END
         };
@@ -22,14 +25,10 @@ public class Maya.View.VAutoHider : Gtk.Bin {
     }
 
     public override void add (Gtk.Widget widget) {
-        var children = main_box.get_children ();
         children.append (widget);
-
-        children.sort (compare_children);
-
-        int index = children.index (widget);
         main_box.add (widget);
-        main_box.reorder_child (widget, index);
+
+        update (widget);
 
         widget.destroy.connect (() => {
             queue_resize ();
@@ -39,8 +38,6 @@ public class Maya.View.VAutoHider : Gtk.Bin {
     }
 
     public void update (Gtk.Widget widget) {
-        var children = main_box.get_children ();
-
         children.sort (compare_children);
 
         int index = children.index (widget);
@@ -50,7 +47,7 @@ public class Maya.View.VAutoHider : Gtk.Bin {
     public override void size_allocate (Gtk.Allocation allocation) {
         base.size_allocate (allocation);
         int global_height = allocation.height;
-        int children_length = (int)main_box.get_children ().length () - 1;
+        int children_length = (int) children.length ();
         if (children_length == 0) {
             more_label.hide ();
             return;
@@ -64,9 +61,11 @@ public class Maya.View.VAutoHider : Gtk.Bin {
         more_label.get_preferred_height (out more_label_height, null);
         more_label.vexpand = true;
         more_label.hide ();
-        foreach (var child in main_box.get_children ()) {
-            if (child == more_label)
+
+        foreach (var child in children) {
+            if (child == more_label) {
                 continue;
+            }
 
             bool last = (shown_children == children_length - 1);
 
@@ -97,7 +96,7 @@ public class Maya.View.VAutoHider : Gtk.Bin {
         int more = children_length - shown_children;
         if (shown_children != children_length && more > 0) {
             more_label.show ();
-            more_label.set_label (_("%u more…").printf ((uint)more));
+            more_label.label = _("%u more…").printf ((uint) more);
         } else {
             more_label.hide ();
         }
@@ -106,15 +105,17 @@ public class Maya.View.VAutoHider : Gtk.Bin {
     public override void get_preferred_width (out int minimum_width, out int natural_width) {
         base.get_preferred_width (out minimum_width, out natural_width);
         more_label.get_preferred_width (out minimum_width, null);
-        if (minimum_width > natural_width)
+        if (minimum_width > natural_width) {
             natural_width = minimum_width;
+        }
     }
 
     public override void get_preferred_height (out int minimum_height, out int natural_height) {
         base.get_preferred_height (out minimum_height, out natural_height);
         more_label.get_preferred_height (out minimum_height, null);
-        if (minimum_height > natural_height)
+        if (minimum_height > natural_height) {
             natural_height = minimum_height;
+        }
     }
 
     public static GLib.CompareFunc<weak Gtk.Widget> compare_children = (a, b) => {


### PR DESCRIPTION
There's no `get_children` in GTK4, so keep our own list of children because `observe_children` is supposedly expensive