### PR TITLE
Update GitHub Actions runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/gettext.yml
+++ b/.github/workflows/gettext.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   gettext:
     name: Gettext
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/elementary/flatpak-platform/runtime:8.2-x86_64
       options: --privileged

--- a/.github/workflows/gettext.yml
+++ b/.github/workflows/gettext.yml
@@ -1,7 +1,7 @@
 name: Gettext Updates
 on:
   push:
-    branches: [master]
+    branches: [master, fix-gettext-workflow]
 jobs:
   gettext:
     name: Gettext


### PR DESCRIPTION
It appears that ubuntu-latest is missing apt-get (?)
